### PR TITLE
Tl90 accessing to old tenancy

### DIFF
--- a/cypress/integration/tenure.feature
+++ b/cypress/integration/tenure.feature
@@ -4,103 +4,113 @@ Feature: Tenure page
     Background:
       Given I am logged in
 
-    # @SmokeTest
-    # Scenario Outline: View resident details
-    #   When I view a Tenure "<tenure>"
-    #   Then the tenure information is displayed
-    #   And the residents information is displayed
+    @SmokeTest
+    Scenario Outline: View resident details
+      When I view a Tenure "<tenure>"
+      Then the tenure information is displayed
+      And the residents information is displayed
       
-    #   Examples:
-    #       | tenure                               |
-    #       | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+      Examples:
+          | tenure                               |
+          | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
 
     @SmokeTest
     Scenario Outline: Navigate to old tenancy files
-      Given the start date for the selected tenure record is before 31 December 2013
+      Given the start date for the selected tenure record is before 31 December 2013 "<tenure>"
       When I view a Tenure "<tenure>"
       Then the Scanned historic tenure records button is displayed
-    
-      
+  
       Examples:
           | tenure                               |
           | 7b91950d-0edf-d926-1cf7-2e187160fd06 |     
 
-    # @SmokeTest
-    # Scenario Outline: No household members
-    #   When I view a Tenure "<tenure>"
-    #   Then the tenure information is displayed
-    #   And there are no household members
+    
+    @SmokeTest
+    Scenario Outline: Navigate to old tenancy files - button not displayed
+      Given the start date for the selected tenure record is after 31 December 2013 "<tenure>"
+      When I view a Tenure "<tenure>"
+      Then the Scanned historic tenure records button is not displayed
+  
+      Examples:
+          | tenure                               |
+          | af53d98f-79cd-55ba-f0bd-5d58e4eecb8b |     
 
-    #   Examples:
-    #       | tenure                               |
-    #       | 5d576bff-59e4-9baf-3f80-0b9cc53d8a97 |
+    @SmokeTest
+    Scenario Outline: No household members
+      When I view a Tenure "<tenure>"
+      Then the tenure information is displayed
+      And there are no household members
 
-    # @SmokeTest
-    # Scenario Outline: View individual household members
-    #   When I view a Tenure "<tenure>"
-    #   Then the tenure information is displayed
-    #   When I select a household member
-    #   Then the household member details are displayed
+      Examples:
+          | tenure                               |
+          | 5d576bff-59e4-9baf-3f80-0b9cc53d8a97 |
 
-    #   Examples:
-    #       | tenure                               |
-    #       | bba2793e-df7d-aa4a-71df-57d067c21036 |
+    @SmokeTest
+    Scenario Outline: View individual household members
+      When I view a Tenure "<tenure>"
+      Then the tenure information is displayed
+      When I select a household member
+      Then the household member details are displayed
 
-    # @SmokeTest
-    # Scenario Outline: No named tenure holders
-    #   When I view a Tenure "<tenure>"
-    #   Then the tenure information is displayed
-    #   And there are no named tenure holders
+      Examples:
+          | tenure                               |
+          | bba2793e-df7d-aa4a-71df-57d067c21036 |
 
-    #   Examples:
-    #       | tenure                                |
-    #       | 920d7a09-766d-413c-9ff9-36bd0d86ab1a  |
+    @SmokeTest
+    Scenario Outline: No named tenure holders
+      When I view a Tenure "<tenure>"
+      Then the tenure information is displayed
+      And there are no named tenure holders
 
-    # @SmokeTest
-    # Scenario Outline: Navigate to personal details
-    #   When I view a Tenure "<tenure>"
-    #   And I select a resident
-    #   Then the resident details are displayed
+      Examples:
+          | tenure                                |
+          | 920d7a09-766d-413c-9ff9-36bd0d86ab1a  |
 
-    #   Examples:
-    #       | tenure                                |
-    #       | 68c6896c-16f1-54d2-3504-847cb438a1b1  |
+    @SmokeTest
+    Scenario Outline: Navigate to personal details
+      When I view a Tenure "<tenure>"
+      And I select a resident
+      Then the resident details are displayed
 
-    # @device
-    # Scenario Outline: Mobile view
-    #   When I am using a mobile viewport "<device>"
-    #   When I view a Tenure "<tenure>"
-    #   And I click the tenure details accordion
-    #   Then the tenure details accordion information is displayed
-    #   When I click the resident details accordion
-    #   Then the residents details accordion information is displayed
+      Examples:
+          | tenure                                |
+          | 68c6896c-16f1-54d2-3504-847cb438a1b1  |
 
-    #   Examples:
-    #     | device        | tenure                               |
-    #     # | ipad-2        | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     # | ipad-mini     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-3      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-4      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-5      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-6      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-6+     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-7      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-8      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-x      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-xr     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | iphone-se2    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     # | macbook-11    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     # | macbook-13    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     # | macbook-15    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     # | macbook-16    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     # | samsung-note9 | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-    #     | samsung-s10   | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    @device
+    Scenario Outline: Mobile view
+      When I am using a mobile viewport "<device>"
+      When I view a Tenure "<tenure>"
+      And I click the tenure details accordion
+      Then the tenure details accordion information is displayed
+      When I click the resident details accordion
+      Then the residents details accordion information is displayed
 
-    # @Accessibility
-    # Scenario Outline: Accessibility Testing
-    #   When I view a Tenure "<tenure>"
-    #   And have no detectable a11y violations
+      Examples:
+        | device        | tenure                               |
+        # | ipad-2        | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        # | ipad-mini     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-3      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-4      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-5      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-6      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-6+     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-7      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-8      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-x      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-xr     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | iphone-se2    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        # | macbook-11    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        # | macbook-13    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        # | macbook-15    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        # | macbook-16    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        # | samsung-note9 | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+        | samsung-s10   | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
 
-    #   Examples:
-    #       | tenure                                |
-    #       | 68c6896c-16f1-54d2-3504-847cb438a1b1  |
+    @Accessibility
+    Scenario Outline: Accessibility Testing
+      When I view a Tenure "<tenure>"
+      And have no detectable a11y violations
+
+      Examples:
+          | tenure                                |
+          | 68c6896c-16f1-54d2-3504-847cb438a1b1  |

--- a/cypress/integration/tenure.feature
+++ b/cypress/integration/tenure.feature
@@ -4,92 +4,103 @@ Feature: Tenure page
     Background:
       Given I am logged in
 
+    # @SmokeTest
+    # Scenario Outline: View resident details
+    #   When I view a Tenure "<tenure>"
+    #   Then the tenure information is displayed
+    #   And the residents information is displayed
+      
+    #   Examples:
+    #       | tenure                               |
+    #       | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+
     @SmokeTest
-    Scenario Outline: View resident details
+    Scenario Outline: Navigate to old tenancy files
+      Given the start date for the selected tenure record is before 31 December 2013
       When I view a Tenure "<tenure>"
-      Then the tenure information is displayed
-      And the residents information is displayed
+      Then the Scanned historic tenure records button is displayed
+    
       
       Examples:
           | tenure                               |
-          | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+          | 7b91950d-0edf-d926-1cf7-2e187160fd06 |     
 
-    @SmokeTest
-    Scenario Outline: No household members
-      When I view a Tenure "<tenure>"
-      Then the tenure information is displayed
-      And there are no household members
+    # @SmokeTest
+    # Scenario Outline: No household members
+    #   When I view a Tenure "<tenure>"
+    #   Then the tenure information is displayed
+    #   And there are no household members
 
-      Examples:
-          | tenure                               |
-          | 5d576bff-59e4-9baf-3f80-0b9cc53d8a97 |
+    #   Examples:
+    #       | tenure                               |
+    #       | 5d576bff-59e4-9baf-3f80-0b9cc53d8a97 |
 
-    @SmokeTest
-    Scenario Outline: View individual household members
-      When I view a Tenure "<tenure>"
-      Then the tenure information is displayed
-      When I select a household member
-      Then the household member details are displayed
+    # @SmokeTest
+    # Scenario Outline: View individual household members
+    #   When I view a Tenure "<tenure>"
+    #   Then the tenure information is displayed
+    #   When I select a household member
+    #   Then the household member details are displayed
 
-      Examples:
-          | tenure                               |
-          | bba2793e-df7d-aa4a-71df-57d067c21036 |
+    #   Examples:
+    #       | tenure                               |
+    #       | bba2793e-df7d-aa4a-71df-57d067c21036 |
 
-    @SmokeTest
-    Scenario Outline: No named tenure holders
-      When I view a Tenure "<tenure>"
-      Then the tenure information is displayed
-      And there are no named tenure holders
+    # @SmokeTest
+    # Scenario Outline: No named tenure holders
+    #   When I view a Tenure "<tenure>"
+    #   Then the tenure information is displayed
+    #   And there are no named tenure holders
 
-      Examples:
-          | tenure                                |
-          | 920d7a09-766d-413c-9ff9-36bd0d86ab1a  |
+    #   Examples:
+    #       | tenure                                |
+    #       | 920d7a09-766d-413c-9ff9-36bd0d86ab1a  |
 
-    @SmokeTest
-    Scenario Outline: Navigate to personal details
-      When I view a Tenure "<tenure>"
-      And I select a resident
-      Then the resident details are displayed
+    # @SmokeTest
+    # Scenario Outline: Navigate to personal details
+    #   When I view a Tenure "<tenure>"
+    #   And I select a resident
+    #   Then the resident details are displayed
 
-      Examples:
-          | tenure                                |
-          | 68c6896c-16f1-54d2-3504-847cb438a1b1  |
+    #   Examples:
+    #       | tenure                                |
+    #       | 68c6896c-16f1-54d2-3504-847cb438a1b1  |
 
-    @device
-    Scenario Outline: Mobile view
-      When I am using a mobile viewport "<device>"
-      When I view a Tenure "<tenure>"
-      And I click the tenure details accordion
-      Then the tenure details accordion information is displayed
-      When I click the resident details accordion
-      Then the residents details accordion information is displayed
+    # @device
+    # Scenario Outline: Mobile view
+    #   When I am using a mobile viewport "<device>"
+    #   When I view a Tenure "<tenure>"
+    #   And I click the tenure details accordion
+    #   Then the tenure details accordion information is displayed
+    #   When I click the resident details accordion
+    #   Then the residents details accordion information is displayed
 
-      Examples:
-        | device        | tenure                               |
-        # | ipad-2        | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        # | ipad-mini     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-3      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-4      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-5      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-6      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-6+     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-7      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-8      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-x      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-xr     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | iphone-se2    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        # | macbook-11    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        # | macbook-13    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        # | macbook-15    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        # | macbook-16    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        # | samsung-note9 | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
-        | samsung-s10   | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #   Examples:
+    #     | device        | tenure                               |
+    #     # | ipad-2        | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     # | ipad-mini     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-3      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-4      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-5      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-6      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-6+     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-7      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-8      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-x      | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-xr     | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | iphone-se2    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     # | macbook-11    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     # | macbook-13    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     # | macbook-15    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     # | macbook-16    | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     # | samsung-note9 | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
+    #     | samsung-s10   | 68c6896c-16f1-54d2-3504-847cb438a1b1 |
 
-    @Accessibility
-    Scenario Outline: Accessibility Testing
-      When I view a Tenure "<tenure>"
-      And have no detectable a11y violations
+    # @Accessibility
+    # Scenario Outline: Accessibility Testing
+    #   When I view a Tenure "<tenure>"
+    #   And have no detectable a11y violations
 
-      Examples:
-          | tenure                                |
-          | 68c6896c-16f1-54d2-3504-847cb438a1b1  |
+    #   Examples:
+    #       | tenure                                |
+    #       | 68c6896c-16f1-54d2-3504-847cb438a1b1  |

--- a/cypress/integration/tenure/tenure.js
+++ b/cypress/integration/tenure/tenure.js
@@ -1,7 +1,13 @@
-import { When, Then } from "cypress-cucumber-preprocessor/steps";
+import { When, Then, Given } from "cypress-cucumber-preprocessor/steps";
 import TenurePageObjects from '../../pageObjects/tenurePage';
 
 const tenurePage = new TenurePageObjects
+
+
+Given('the start date for the selected tenure record is before 31 December 2013', () => {
+    //update this
+    console.log('update this')
+})
 
 When('I view a Tenure {string}', (record) => {
     tenurePage.visit(record)
@@ -20,6 +26,7 @@ Then('the household member details are displayed', () => {
     cy.url().should('include', '/person')
 })
 
+
 And('I select a resident', () => {
     tenurePage.viewResidentButton().should('have.attr', 'href').and('include', '/person')
     tenurePage.viewResidentButton().eq(0).click()
@@ -27,6 +34,10 @@ And('I select a resident', () => {
 
 Then('the resident details are displayed', () => {
     cy.url().should('include', '/person')
+})
+
+Then ('Then the Scanned historic tenure records button is displayed',() => {
+    tenurePage.scannedHistoricTenureRecords().should(vis)
 })
 
 And('I click the tenure details accordion', () => {
@@ -47,4 +58,8 @@ Then('the residents details accordion information is displayed', () => {
 
 Then('the tenure details accordion information is displayed', () => {
     tenurePage.tenureDetailsAccordionInformation()
+})
+
+Then('the Scanned historic tenure records button is displayed', () => {
+    tenurePage.scannedHistoricTenureRecords()
 })

--- a/cypress/integration/tenure/tenure.js
+++ b/cypress/integration/tenure/tenure.js
@@ -1,12 +1,28 @@
 import { When, Then, Given } from "cypress-cucumber-preprocessor/steps";
 import TenurePageObjects from '../../pageObjects/tenurePage';
+import tenure from "../../../api/tenure";
 
 const tenurePage = new TenurePageObjects
 
 
-Given('the start date for the selected tenure record is before 31 December 2013', () => {
-    //update this
-    console.log('update this')
+Given('the start date for the selected tenure record is before 31 December 2013 {string}', async (tenureId) => {
+    const getResponse = await tenure.getTenure(tenureId)
+    cy.log(`Status code ${getResponse.status} returned`)
+    var startDate =  new Date(getResponse.data.startOfTenureDate)
+    var threshold =  new Date(2013, 12, 31)
+    cy.log('startDate', startDate)
+    cy.log('threshold', threshold)
+    expect(startDate).to.lessThan(threshold)
+})
+
+Given('the start date for the selected tenure record is after 31 December 2013 {string}', async (tenureId) => {
+    const getResponse = await tenure.getTenure(tenureId)
+    cy.log(`Status code ${getResponse.status} returned`)
+    var startDate =  new Date(getResponse.data.startOfTenureDate)
+    var threshold =  new Date(2013, 12, 31)
+    cy.log('startDate', startDate)
+    cy.log('threshold', threshold)
+    expect(startDate).to.greaterThan(threshold)
 })
 
 When('I view a Tenure {string}', (record) => {
@@ -61,5 +77,9 @@ Then('the tenure details accordion information is displayed', () => {
 })
 
 Then('the Scanned historic tenure records button is displayed', () => {
-    tenurePage.scannedHistoricTenureRecords()
+    tenurePage.scannedHistoricTenureRecords().should('be.visible')
+})
+
+Then('the Scanned historic tenure records button is not displayed', () => {
+    tenurePage.scannedHistoricTenureRecords().should('not.exist')
 })

--- a/cypress/pageObjects/tenurePage.js
+++ b/cypress/pageObjects/tenurePage.js
@@ -56,6 +56,10 @@ class TenurePageObjects {
     return cy.get('[class="comment__item --center"]')
   }
 
+  scannedHistoricTenureRecords(){
+    return cy.get('[class="govuk-button lbh-button govuk-button--secondary lbh-button--secondary"]')
+  }
+
   tenureDetailsAccordionInformation() {
       this.tenureViewSidebar().contains('Start date')
       this.tenureViewSidebar().contains('End date')

--- a/cypress/pageObjects/tenurePage.js
+++ b/cypress/pageObjects/tenurePage.js
@@ -57,7 +57,7 @@ class TenurePageObjects {
   }
 
   scannedHistoricTenureRecords(){
-    return cy.get('[class="govuk-button lbh-button govuk-button--secondary lbh-button--secondary"]')
+    return cy.contains('Scanned historic tenure records')
   }
 
   tenureDetailsAccordionInformation() {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,10 +8,10 @@ const cucumber = require("cypress-cucumber-preprocessor").default;
 const { getConfiguration } = require("./configuration");
 
 module.exports = async (on, config) => {
-  // config.featureToggles = (await getConfiguration(config.env)) || {};
-  // on("before:browser:launch", (browser = {}, launchOptions) => {
-  // prepareAudit(launchOptions);
-  // });
+  config.featureToggles = (await getConfiguration(config.env)) || {};
+  on("before:browser:launch", (browser = {}, launchOptions) => {
+  prepareAudit(launchOptions);
+  });
   on("file:preprocessor", cucumber());
   on("task", {
     lighthouse: lighthouse((lighthouseReport) => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,10 +8,10 @@ const cucumber = require("cypress-cucumber-preprocessor").default;
 const { getConfiguration } = require("./configuration");
 
 module.exports = async (on, config) => {
-  config.featureToggles = (await getConfiguration(config.env)) || {};
-  on("before:browser:launch", (browser = {}, launchOptions) => {
-  prepareAudit(launchOptions);
-  });
+  // config.featureToggles = (await getConfiguration(config.env)) || {};
+  // on("before:browser:launch", (browser = {}, launchOptions) => {
+  // prepareAudit(launchOptions);
+  // });
   on("file:preprocessor", cucumber());
   on("task", {
     lighthouse: lighthouse((lighthouseReport) => {


### PR DESCRIPTION
Added two scenarios

**AC1. Display Scanned historic tenure button based on date of tenure start**

Given I’m viewing a tenure details page

And the start date for the selected tenure record is before 31/12/2013

Then the ‘Scanned historic tenure records’ button is displayed 

**AC1.1 Hide Scanned historic tenure button based on date of tenure start**

Given I’m viewing a tenure details page

And the start date for the selected tenure record is after 31/12/2013

Then the ‘Scanned historic tenure records’ button is hidden 

