### PR TITLE
Added ignore tags to property and comments

### DIFF
--- a/cypress/integration/property-comments.feature
+++ b/cypress/integration/property-comments.feature
@@ -3,6 +3,7 @@
 @common
 @root
 
+@ignore
 Feature: Property Comment
     I want to create and view property's comments
 

--- a/cypress/integration/property.feature
+++ b/cypress/integration/property.feature
@@ -4,6 +4,7 @@
 @property
 @root
 
+@ignore
 Feature: Property Page
 
     View property page


### PR DESCRIPTION
Currently property and property comments test failed due to the workorder (repairs) apis where a token is not set up for e2e test account.

Until we assign a correct token, we mark ignore tags to these features. 