### PR TITLE
Removed cypress/fixtures/ from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ docker/dynamodb/shared-local-instance.db
 .idea/workspace.xml
 cypress/cucumber-json/
 cucumber-messages.ndjson
-
-
-cypress/fixtures/


### PR DESCRIPTION
Removed cypress/fixtures/ from .gitignore file - this allows fixtures files to be added and uploaded to Github for them to be used in the E2E tests.