### PR TITLE
Reinstating the tests for displaying CAs

### DIFF
--- a/cypress/e2e/cautionaryAlerts.feature
+++ b/cypress/e2e/cautionaryAlerts.feature
@@ -18,7 +18,7 @@ Feature: Create Cautionary Alerts
     When I click on Save cautionary alert button
     Then I am on the Person details page
     And I can see the section Cautionary Alerts with a Red bell icon
-    # And I can see the Cautionary Alert type
+    And I can see the Cautionary Alert type
 
   Scenario: 'Update cautionary alert' on Check and confirm Cautionary alert page by clicking on the 'Change link'
     Then I am on the Person details page for Alerts
@@ -57,9 +57,8 @@ Feature: Create Cautionary Alerts
     And I can see the 'Description' is updated with the new value
     When I click on Save cautionary alert button
     Then I am on the Person details page
-    And I can see a message referring me to the cautionary alert spreadsheet
     And I can see the section Cautionary Alerts with a Red bell icon
-    # And I can see the Cautionary Alert type with the new value
+    And I can see the Cautionary Alert type with the new value
 
 
   Scenario: Verify Validation error messages in Add Cautionary Alerts page

--- a/cypress/e2e/cautionaryAlerts/cautionaryAlerts.js
+++ b/cypress/e2e/cautionaryAlerts/cautionaryAlerts.js
@@ -100,18 +100,13 @@ When("I click on Save cautionary alert button", () => {
 And("I can see the section Cautionary Alerts with a Red bell icon", () => {
     cautionaryAlertPO.redBellIconAlert().should('exist');
 });
-
-And("I can see a message referring me to the cautionary alert spreadsheet", () => {
-    cy.contains('Alert(s) found. Check Cautionary Alerts Spreadsheet for details.')
+And("I can see the Cautionary Alert type with the new value", () => {
+  cy.contains('Beware of aggressive pets');
 })
-// Temporarily disabled pending database fix:
-// And("I can see the Cautionary Alert type with the new value", () => {
-//   cy.contains('Beware of aggressive pets');
-// })
-// And('I can see the Cautionary Alert type', () => {
-//     // cy.contains('Verbal Abuse');
-//     cy.contains('Do not visit alone');
-// });
+And('I can see the Cautionary Alert type', () => {
+    // cy.contains('Verbal Abuse');
+    cy.contains('Do not visit alone');
+});
 And("I can see the Red Bell icon next to the person name", () => {
 
 });

--- a/cypress/e2e/cautionaryAlerts/cautionaryAlerts.js
+++ b/cypress/e2e/cautionaryAlerts/cautionaryAlerts.js
@@ -101,7 +101,7 @@ And("I can see the section Cautionary Alerts with a Red bell icon", () => {
     cautionaryAlertPO.redBellIconAlert().should('exist');
 });
 And("I can see the Cautionary Alert type with the new value", () => {
-  cy.contains('Beware of aggressive pets');
+  cy.contains('Dangerous Animals');
 })
 And('I can see the Cautionary Alert type', () => {
     // cy.contains('Verbal Abuse');
@@ -148,7 +148,7 @@ When("I update the {string} with a new value", (text) => {
             break;
         }
         case 'Type of caution': {
-            cautionaryAlertPO.typeOfCaution().select('Beware of aggressive pets');
+            cautionaryAlertPO.typeOfCaution().select('Dangerous Animals');
             break;
         }
         case 'Description': {
@@ -175,7 +175,7 @@ And("I can see the {string} is updated with the new value", (text) => {
         }
         case 'Type of caution': {
             cy.contains('Type of caution');
-            cy.get(':nth-child(3) > .govuk-summary-list__value').should('contain.text','Beware of aggressive pets');
+            cy.get(':nth-child(3) > .govuk-summary-list__value').should('contain.text','Dangerous Animals');
             break;
         }
         case 'Description': {

--- a/cypress/e2e/cautionaryAlerts/cautionaryAlerts.js
+++ b/cypress/e2e/cautionaryAlerts/cautionaryAlerts.js
@@ -21,7 +21,7 @@ And("I enter Date of Incident as Day Month and Year", () => {
 });
 And("select Type of Caution", () => {
    // cautionaryAlertPO.typeOfCaution().select('Verbal abuse');
-    cautionaryAlertPO.typeOfCaution().select('Do not visit alone');
+    cautionaryAlertPO.typeOfCaution().select('No Lone Visits');
 });
 And("I enter Description of Incident", () => {
     cautionaryAlertPO.descriptionOfIncident().clear().type('This is a test incident for verbal abuse happened on the date above')
@@ -90,7 +90,7 @@ And("the Cautionary alert details are displayed", () => {
     cy.get(':nth-child(2) > .govuk-summary-list__value').should('contain.text','01 12 2022');
     cy.contains('Type of caution');
     //cy.get(':nth-child(3) > .govuk-summary-list__value').should('contain.text','Verbal Abuse');
-    cy.get(':nth-child(3) > .govuk-summary-list__value').should('contain.text','Do not visit alone');
+    cy.get(':nth-child(3) > .govuk-summary-list__value').should('contain.text','No Lone Visits');
     cy.contains('Description');
     cy.get(':nth-child(4) > .govuk-summary-list__value').should('contain.text','This is a test incident for verbal abuse happened on the date above');
 });
@@ -105,7 +105,7 @@ And("I can see the Cautionary Alert type with the new value", () => {
 })
 And('I can see the Cautionary Alert type', () => {
     // cy.contains('Verbal Abuse');
-    cy.contains('Do not visit alone');
+    cy.contains('No Lone Visits');
 });
 And("I can see the Red Bell icon next to the person name", () => {
 


### PR DESCRIPTION
Now that the CA database has been fixed with correct data, we can display the alerts again.

The changes to these tests correspond with changes to the person and property pages to display alerts again as before.