### PR TITLE
"View/End Cautionary Alert" functionality tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ commands:
                           export CYPRESS_EQUALITY_DETAILS_ENDPOINT=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/equality-information-api-url --query Parameter.Value --output text) ;
                           export CYPRESS_PERSON_ENDPOINT=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/person-api-url --query Parameter.Value --output text) ;
                           export CYPRESS_TENURE_ENDPOINT=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/tenure-api-url --query Parameter.Value --output text) ;
+                          export CYPRESS_CAUTIONARY_ALERT_ENDPOINT=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alerts-api-url --query Parameter.Value --output text) ;
                           export CYPRESS_ENVIRONMENT=<<parameters.stage>> ;
                           export CYPRESS_AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile default) ;
                           export CYPRESS_AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile default) ;

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This sets the access token depending upon the environment, you can create one fo
 
 >"TENURE_ENDPOINT": ${tenureEndpoint}
 
+>"CAUTIONARY_ALERT_ENDPOINT": ${cautionaryAlertEndpoint}
+
 These are the API gateways as taken from the AWS parameter store. The properties can be set as follows: `https://${apiGateway}.execute-api.eu-west-2.amazonaws.com/${environment}/api/${apiVersion}`
 
 This list is subject to change as the tests start to leverage more of the API's maturing functionality. If in doubt, check the [CircleCI config](https://github.com/LBHackney-IT/mtfh-tl-e2e-tests/blob/83f7a7c8b13124a7d7ecac845ed5a235abe87fd9/.circleci/config.yml#L80) to see exactly what endpoints the tests need to run.

--- a/api/cautionary-alert.js
+++ b/api/cautionary-alert.js
@@ -1,0 +1,18 @@
+import envConfig from "../environment-config";
+
+const cautionaryAlertEndpoint =  Cypress.env('CAUTIONARY_ALERT_ENDPOINT')
+const url = `${cautionaryAlertEndpoint}/cautionary-alerts`
+
+const createCautionaryAlert = (cautionaryAlert) => new Cypress.Promise((resolve) => {
+        cy.request({
+            method: 'POST',
+            body: cautionaryAlert,
+            url,
+            headers: { Authorization: `Bearer ${envConfig.gssoTestKey}` }
+        }).then(response => {
+            resolve(response);
+        })
+    });
+
+
+export default createCautionaryAlert;

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -15,6 +15,16 @@ export const saveFixtureData = (tableName, keys, fixtureData, response) => new C
     resolve(fixtureData)
 })
 
+export const saveNonDynamoFixture = (entityName, fixtureData, response) => new Cypress.Promise((resolve, reject) => {
+  if (fixtureData)
+    cy.writeFile(`cypress/fixtures/${entityName}.json`, fixtureData);
+
+  if (response)
+    resolve(response);
+
+  resolve(fixtureData);
+});
+
 export const queueDeletePersonWithId = (id) => {
     saveFixtureData("Persons", { id: id })
 }

--- a/api/models/requests/cautionaryAlertModel.js
+++ b/api/models/requests/cautionaryAlertModel.js
@@ -1,0 +1,22 @@
+export const cautionaryAlert = (person, asset) => ({
+  assureReference: "121212",
+  incidentDate: "2023-02-02",
+  incidentDescription: "This was a test of our emergency preparedness.",
+  alert: {
+      code: "AND",
+      description: "Dangerous Animals"
+  },
+  assetDetails: {
+      id: asset.id,
+      propertyReference: asset.assetId,
+      uprn: "100021065711",
+      fullAddress: asset.assetAddress.addressLine1
+        + asset.assetAddress.addressLine2
+        + asset.assetAddress.addressLine3
+        + asset.assetAddress.postCode
+  },
+  personDetails: {
+      id: person.id,
+      name: `${person.firstName} ${person.surname}`
+  }
+});

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -1,0 +1,10 @@
+Feature: Create Cautionary Alerts
+
+  Background:
+    Given I am logged in
+    And There's a person with a cautionary alert
+
+  Scenario: Cautionary Alert information can be viewed by getting to it from Person page
+    When I'm on the Cautionary Alert View page
+    Then The page title should reflect the page's purpose & contain person's name
+    And The cautionary alert table should show the correct information

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -12,12 +12,25 @@ Feature: Create Cautionary Alerts
   Scenario: Cautionary Alert 'back' button switches to Person page
     When I'm on the Cautionary Alert View page
     And I click on the 'back' button
-    Then I should be moved back to the Person page
+    Then I get redirected to back to the person page
     And I should see the cautionary alert I navigated from
 
   Scenario: Cautionary Alert 'close' button switches to Person page
     When I'm on the Cautionary Alert View page
     And I click on the 'close' button
-    Then I should be moved back to the Person page
+    Then I get redirected to back to the person page
     And I should see the cautionary alert I navigated from
 
+  Scenario: Cautionary Alert 'end alert' button reveals extra alert editing options and UI changes
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    Then The 'end date' input should become visible
+    And The 'end alert' button gets replaced with 'confirm' button
+
+  Scenario: Cautionary Alert can be ended with specified 'end date'
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    And I select the 'end date' for the alert
+    And I click the 'confirm' button
+    Then I get redirected to back to the person page
+    And The cautionary alert should not be listed under the person anymore

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -51,3 +51,12 @@ Feature: Create Cautionary Alerts
     And I fill in a valid 'end date' for the alert
     Then The 'end date' input error message is NOT displayed on the screen
     And The 'confirm' button gets unlocked
+
+  Scenario: When an 'End Alert' form submission fails, a Page Error is displayed
+    And Given an impending 'End Alert' endpoint failure
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    And I fill in a valid 'end date' for the alert
+    And I click the 'confirm' button
+    Then The page error is displayed notifying the user about request failure
+    And User should stay on the manage cautionary alert page

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -32,7 +32,22 @@ Feature: Create Cautionary Alerts
     When I'm on the person's with cautionary alert page
     And I navigate to that person's cautionary alert's page
     And I click on the 'end alert' button
-    And I select the 'end date' for the alert
+    And I fill in a valid 'end date' for the alert
     And I click the 'confirm' button
     Then I get redirected to back to the person page
     And The cautionary alert should not be listed under the person anymore
+
+  Scenario: End date input shows the validation error when the entered date is not valid
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    And I fill in an 'end date' for the alert that is not allowed
+    Then The 'end date' input error message gets displayed on the screen
+    And The 'confirm' button gets locked out
+
+  Scenario: End date input hides the validation error when the entered date is corrected
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    And I fill in an 'end date' for the alert that is not allowed
+    And I fill in a valid 'end date' for the alert
+    Then The 'end date' input error message is NOT displayed on the screen
+    And The 'confirm' button gets unlocked

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -8,3 +8,16 @@ Feature: Create Cautionary Alerts
     When I'm on the Cautionary Alert View page
     Then The page title should reflect the page's purpose & contain person's name
     And The cautionary alert table should show the correct information
+
+  Scenario: Cautionary Alert 'back' button switches to Person page
+    When I'm on the Cautionary Alert View page
+    And I click on the 'back' button
+    Then I should be moved back to the Person page
+    And I should see the cautionary alert I navigated from
+
+  Scenario: Cautionary Alert 'close' button switches to Person page
+    When I'm on the Cautionary Alert View page
+    And I click on the 'close' button
+    Then I should be moved back to the Person page
+    And I should see the cautionary alert I navigated from
+

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -5,7 +5,8 @@ Feature: Create Cautionary Alerts
     And There's a person with a cautionary alert
 
   Scenario: Cautionary Alert information can be viewed by getting to it from Person page
-    When I'm on the Cautionary Alert View page
+    When I'm on the person's with cautionary alert page
+    And I navigate to that person's cautionary alert's page
     Then The page title should reflect the page's purpose & contain person's name
     And The cautionary alert table should show the correct information
 
@@ -28,7 +29,8 @@ Feature: Create Cautionary Alerts
     And The 'end alert' button gets replaced with 'confirm' button
 
   Scenario: Cautionary Alert can be ended with specified 'end date'
-    When I'm on the Cautionary Alert View page
+    When I'm on the person's with cautionary alert page
+    And I navigate to that person's cautionary alert's page
     And I click on the 'end alert' button
     And I select the 'end date' for the alert
     And I click the 'confirm' button

--- a/cypress/e2e/cautionaryAlertViewAndEdit.feature
+++ b/cypress/e2e/cautionaryAlertViewAndEdit.feature
@@ -16,17 +16,20 @@ Feature: Create Cautionary Alerts
     Then I get redirected to back to the person page
     And I should see the cautionary alert I navigated from
 
-  Scenario: Cautionary Alert 'close' button switches to Person page
-    When I'm on the Cautionary Alert View page
-    And I click on the 'close' button
-    Then I get redirected to back to the person page
-    And I should see the cautionary alert I navigated from
-
-  Scenario: Cautionary Alert 'end alert' button reveals extra alert editing options and UI changes
+  Scenario: Cautionary Alert 'end alert' button enters the 'edit mode'
     When I'm on the Cautionary Alert View page
     And I click on the 'end alert' button
     Then The 'end date' input should become visible
+    And The 'cancel' button becomes visible
     And The 'end alert' button gets replaced with 'confirm' button
+
+  Scenario: Cautionary Alert 'cancel' button exits the 'edit mode'
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    And I click on the 'cancel' button
+    Then The 'end date' input should become hidden
+    And The 'cancel' button should become hidden
+    And The 'confirm' button gets replaced with 'end alert' button
 
   Scenario: Cautionary Alert can be ended with specified 'end date'
     When I'm on the person's with cautionary alert page
@@ -41,6 +44,13 @@ Feature: Create Cautionary Alerts
     When I'm on the Cautionary Alert View page
     And I click on the 'end alert' button
     And I fill in an 'end date' for the alert that is not allowed
+    Then The 'end date' input error message gets displayed on the screen
+    And The 'confirm' button gets locked out
+
+  Scenario: End date input shows the validation error when no date is entered
+    When I'm on the Cautionary Alert View page
+    And I click on the 'end alert' button
+    And I click the 'confirm' button
     Then The 'end date' input error message gets displayed on the screen
     And The 'confirm' button gets locked out
 

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -1,0 +1,38 @@
+import { Given, And, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+import CautionaryAlertViewPageObject from "../../pageObjects/CautionaryAlertViewPage";
+
+const cautionaryAlertViewPO = new CautionaryAlertViewPageObject();
+
+When("I'm on the Cautionary Alert View page", () => {
+  cy.getCautionaryAlertFixture().then((cautionaryAlerts) => {
+    const cautionaryAlertId = cautionaryAlerts[0].alertId;
+    cautionaryAlertViewPO.visit(cautionaryAlertId);
+  });
+});
+
+Then("The page title should reflect the page's purpose & contain person's name", () => {
+  cy.getPersonFixture().then((expectedPerson) => {
+    const personFirstName = expectedPerson.firstName;
+    const personLastName = expectedPerson.surname;
+
+    cautionaryAlertViewPO
+      .pageTitle()
+      .should('contain', 'Cautionary Alert for')
+      .and('contain', personFirstName)
+      .and('contain', personLastName);
+  });
+});
+
+And("The cautionary alert table should show the correct information", () => {
+  cy.getCautionaryAlertFixture().then((cautionaryAlerts) => {
+    const cautionaryAlert = cautionaryAlerts[0];
+
+    cautionaryAlertViewPO.dateOfIncidentValue().should('contain', cautionaryAlert.dateOfIncident);
+    cautionaryAlertViewPO.alertCodeValue().should('contain', cautionaryAlert.code);
+    cautionaryAlertViewPO.cautionOnSystemValue().should('contain', cautionaryAlert.cautionOnSystem)  ;  
+    cautionaryAlertViewPO.personNameValue().should('contain', cautionaryAlert.name);
+    cautionaryAlertViewPO.reasonValue().should('contain', cautionaryAlert.reason);
+    cautionaryAlertViewPO.assureReferenceValue().should('contain', cautionaryAlert.assureReference);
+  });
+});
+

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -69,8 +69,16 @@ And("I should see the cautionary alert I navigated from", () => {
   }); 
 });
 
-And("I click on the 'close' button", () => {
-  cautionaryAlertViewPO.closeButton().click();
+And("I click on the 'cancel' button", () => {
+  cautionaryAlertViewPO.cancelButton().click();
+});
+
+And("The 'cancel' button becomes visible", () => {
+  cautionaryAlertViewPO.cancelButton().should('exist');
+});
+
+And("The 'cancel' button should become hidden", () => {
+  cautionaryAlertViewPO.cancelButton().should('not.exist');
 });
 
 And("I click on the 'end alert' button", () => {
@@ -81,9 +89,18 @@ Then("The 'end date' input should become visible", () => {
   cautionaryAlertViewPO.endDateInput().should('exist');
 });
 
+Then("The 'end date' input should become hidden", () => {
+  cautionaryAlertViewPO.endDateInput().should('not.exist');
+});
+
 And("The 'end alert' button gets replaced with 'confirm' button", () => {
   cautionaryAlertViewPO.endAlertButton().should('not.exist');
   cautionaryAlertViewPO.confirmButton().should('exist');
+});
+
+And("The 'confirm' button gets replaced with 'end alert' button", () => {
+  cautionaryAlertViewPO.endAlertButton().should('exist');
+  cautionaryAlertViewPO.confirmButton().should('not.exist');
 });
 
 And("I fill in a valid 'end date' for the alert", () => {

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -86,12 +86,15 @@ And("The 'end alert' button gets replaced with 'confirm' button", () => {
   cautionaryAlertViewPO.confirmButton().should('exist');
 });
 
-And("I select the 'end date' for the alert", () => {
+And("I fill in a valid 'end date' for the alert", () => {
   const today = new Date();
-  const day = today.getDay().toString().padStart(2, '0');
+  const day = today.getDate().toString().padStart(2, '0');
   const month = (today.getMonth() + 1).toString().padStart(2, '0');
   const year = today.getFullYear().toString();
-  cautionaryAlertViewPO.endDateInput().click().type(`${year}-${month}-${day}`);
+
+  // On the UI it's DD-MM-YYYY, however, cypress demands the opposite for it to work as expected.
+  const typedDate = `${year}-${month}-${day}`;
+  cautionaryAlertViewPO.endDateInput().click().type(typedDate);
 });
 
 And("I click the 'confirm' button", () => {
@@ -102,4 +105,28 @@ And("The cautionary alert should not be listed under the person anymore", () => 
   // ensure page is loaded before the cautionary alert assertion
   personPO.pageTitle().should('exist');
   personPO.nthCautionaryAlert(0).should('not.exist');
+});
+
+And("I fill in an 'end date' for the alert that is not allowed", () => {
+  const today = new Date();
+  const day = (today.getDate() + 1).toString().padStart(2, '0');
+  const month = (today.getMonth() + 1).toString().padStart(2, '0');
+  const year = today.getFullYear().toString();
+  cautionaryAlertViewPO.endDateInput().focus().click().type(`${year}-${month}-${day}`);
+});
+
+Then("The 'end date' input error message gets displayed on the screen", () => {
+  cautionaryAlertViewPO.endDateInputError().should('exist');
+});
+
+Then("The 'end date' input error message is NOT displayed on the screen", () => {
+  cautionaryAlertViewPO.endDateInputError().should('not.exist');
+});
+
+And("The 'confirm' button gets locked out", () => {
+  cautionaryAlertViewPO.confirmButton().should('be.disabled');
+});
+
+And("The 'confirm' button gets unlocked", () => {
+  cautionaryAlertViewPO.confirmButton().should('not.be.disabled');
 });

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -42,7 +42,7 @@ And("I click on the 'back' button", () => {
   cautionaryAlertViewPO.backLink().click();
 });
 
-Then("I should be moved back to the Person page", () => {
+Then("I get redirected to back to the person page", () => {
   cy.getPersonFixture().then((person) => {
     const personId = person.id;
     cy.url().should('include', `/person/${personId}`) // => true
@@ -58,4 +58,35 @@ And("I should see the cautionary alert I navigated from", () => {
 
 And("I click on the 'close' button", () => {
   cautionaryAlertViewPO.closeButton().click();
+});
+
+And("I click on the 'end alert' button", () => {
+  cautionaryAlertViewPO.endAlertButton().click();
+});
+
+Then("The 'end date' input should become visible", () => {
+  cautionaryAlertViewPO.endDateInput().should('exist');
+});
+
+And("The 'end alert' button gets replaced with 'confirm' button", () => {
+  cautionaryAlertViewPO.endAlertButton().should('not.exist');
+  cautionaryAlertViewPO.confirmButton().should('exist');
+});
+
+And("I select the 'end date' for the alert", () => {
+  const today = new Date();
+  const day = today.getDay().toString().padStart(2, '0');
+  const month = (today.getMonth() + 1).toString().padStart(2, '0');
+  const year = today.getFullYear().toString();
+  cautionaryAlertViewPO.endDateInput().click().type(`${year}-${month}-${day}`);
+});
+
+And("I click the 'confirm' button", () => {
+  cautionaryAlertViewPO.confirmButton().click();
+});
+
+And("The cautionary alert should not be listed under the person anymore", () => {
+  // ensure page is loaded before the cautionary alert assertion
+  personPO.pageTitle().should('exist');
+  personPO.nthCautionaryAlert(0).should('not.exist');
 });

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -130,3 +130,21 @@ And("The 'confirm' button gets locked out", () => {
 And("The 'confirm' button gets unlocked", () => {
   cautionaryAlertViewPO.confirmButton().should('not.be.disabled');
 });
+
+And("Given an impending 'End Alert' endpoint failure", () => {
+  cy.getCautionaryAlertFixture().then((cautionaryAlerts) => {
+    const cautionaryAlertId = cautionaryAlerts[0].alertId;
+    cy.setUpEndAlertError(cautionaryAlertId);
+  });
+});
+
+Then("The page error is displayed notifying the user about request failure", () => {
+  cautionaryAlertViewPO.pageError().should('exist');
+});
+
+And("User should stay on the manage cautionary alert page", () => {
+  cy.getCautionaryAlertFixture().then((cautionaryAlerts) => {
+    const cautionaryAlertId = cautionaryAlerts[0].alertId;
+    cy.url().should('include', `/cautionary-alerts/alert/${cautionaryAlertId}`);
+  });
+});

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -1,6 +1,8 @@
 import { Given, And, When, Then } from "@badeball/cypress-cucumber-preprocessor";
 import CautionaryAlertViewPageObject from "../../pageObjects/CautionaryAlertViewPage";
+import PersonPageObjects from "../../pageObjects/personPage";
 
+const personPO = new PersonPageObjects();
 const cautionaryAlertViewPO = new CautionaryAlertViewPageObject();
 
 When("I'm on the Cautionary Alert View page", () => {
@@ -36,3 +38,24 @@ And("The cautionary alert table should show the correct information", () => {
   });
 });
 
+And("I click on the 'back' button", () => {
+  cautionaryAlertViewPO.backLink().click();
+});
+
+Then("I should be moved back to the Person page", () => {
+  cy.getPersonFixture().then((person) => {
+    const personId = person.id;
+    cy.url().should('include', `/person/${personId}`) // => true
+  });
+});
+
+And("I should see the cautionary alert I navigated from", () => {
+  cy.getCautionaryAlertFixture().then((cautionaryAlerts) => {
+    const cautionaryAlert = cautionaryAlerts[0];
+    personPO.nthCautionaryAlert(0).should('contain', cautionaryAlert.cautionOnSystem);
+  }); 
+});
+
+And("I click on the 'close' button", () => {
+  cautionaryAlertViewPO.closeButton().click();
+});

--- a/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
+++ b/cypress/e2e/cautionaryAlertViewAndEdit/cautionaryAlertViewAndEdit.js
@@ -12,6 +12,19 @@ When("I'm on the Cautionary Alert View page", () => {
   });
 });
 
+When("I'm on the person's with cautionary alert page", () => {
+  cy.getPersonFixture().then((person) => {
+    const personId = person.id;
+    personPO.visit(personId);
+  });
+});
+
+And("I navigate to that person's cautionary alert's page", () => {
+  const cautionaryAlertLink = personPO.nthCautionaryAlert(0);
+  cautionaryAlertLink.should('exist');
+  cautionaryAlertLink.click();
+});
+
 Then("The page title should reflect the page's purpose & contain person's name", () => {
   cy.getPersonFixture().then((expectedPerson) => {
     const personFirstName = expectedPerson.firstName;

--- a/cypress/pageObjects/CautionaryAlertViewPage.js
+++ b/cypress/pageObjects/CautionaryAlertViewPage.js
@@ -11,6 +11,9 @@ class CautionaryAlertViewPageObject {
     pageTitle = () => this.getByTestIdAttr("manage-ca-title");
     backLink = () => this.getByTestIdAttr("back-link");
     closeButton =() => this.getByTestIdAttr("close-link");
+    endAlertButton =() => this.getByTestIdAttr("end-alert-button");
+    endDateInput = () => this.getByTestIdAttr("end-date-input");
+    confirmButton = () => this.getByTestIdAttr("confirm-button");
 
     // Details table items
     dateOfIncidentValue     = () => this.caTableItemValue("dateOfIncident");

--- a/cypress/pageObjects/CautionaryAlertViewPage.js
+++ b/cypress/pageObjects/CautionaryAlertViewPage.js
@@ -15,6 +15,7 @@ class CautionaryAlertViewPageObject {
     endDateInput = () => this.getByTestIdAttr("end-date-input");
     confirmButton = () => this.getByTestIdAttr("confirm-button");
     endDateInputError = () => this.getByTestIdAttr("end-date-error");
+    pageError = () => this.getByTestIdAttr("page-error");
 
     // Details table items
     dateOfIncidentValue     = () => this.caTableItemValue("dateOfIncident");

--- a/cypress/pageObjects/CautionaryAlertViewPage.js
+++ b/cypress/pageObjects/CautionaryAlertViewPage.js
@@ -8,14 +8,14 @@ class CautionaryAlertViewPageObject {
     }
 
     // Specific UI items
-    pageTitle = () => this.getByTestIdAttr("manage-ca-title");
-    backLink = () => this.getByTestIdAttr("back-link");
-    closeButton =() => this.getByTestIdAttr("close-link");
-    endAlertButton =() => this.getByTestIdAttr("end-alert-button");
-    endDateInput = () => this.getByTestIdAttr("end-date-input");
-    confirmButton = () => this.getByTestIdAttr("confirm-button");
-    endDateInputError = () => this.getByTestIdAttr("end-date-error");
-    pageError = () => this.getByTestIdAttr("page-error");
+    pageTitle          = () => this.getByTestIdAttr("manage-ca-title");
+    backLink           = () => this.getByTestIdAttr("back-link");
+    cancelButton       = () => this.getByTestIdAttr("cancel-changes");
+    endAlertButton     = () => this.getByTestIdAttr("end-alert-button");
+    endDateInput       = () => this.getByTestIdAttr("end-date-input");
+    confirmButton      = () => this.getByTestIdAttr("confirm-button");
+    endDateInputError  = () => this.getByTestIdAttr("end-date-error");
+    pageError          = () => this.getByTestIdAttr("page-error");
 
     // Details table items
     dateOfIncidentValue     = () => this.caTableItemValue("dateOfIncident");

--- a/cypress/pageObjects/CautionaryAlertViewPage.js
+++ b/cypress/pageObjects/CautionaryAlertViewPage.js
@@ -1,0 +1,25 @@
+const envConfig = require('../../environment-config');
+
+class CautionaryAlertViewPageObject {
+    // Actions
+    visit(cautionaryAlertId) {
+        cy.visit(`${envConfig.baseUrl}/${envConfig.alertPreviewUrl}/${cautionaryAlertId}`);
+        cy.injectAxe();
+    }
+
+    // Specific UI items
+    pageTitle = () => cy.getByTestId("manage-ca-title");
+
+    // Details table items
+    dateOfIncidentValue     = () => this.caTableItemValue("dateOfIncident");
+    alertCodeValue          = () => this.caTableItemValue("code");
+    cautionOnSystemValue    = () => this.caTableItemValue("cautionOnSystem");    
+    personNameValue         = () => this.caTableItemValue("personName");
+    reasonValue             = () => this.caTableItemValue("reason");
+    assureReferenceValue    = () => this.caTableItemValue("assureReference");
+
+    // Reuse purpose
+    caTableItemValue = (itemName) => cy.getByTestId(`${itemName}-value`);
+}
+
+export default CautionaryAlertViewPageObject;

--- a/cypress/pageObjects/CautionaryAlertViewPage.js
+++ b/cypress/pageObjects/CautionaryAlertViewPage.js
@@ -14,6 +14,7 @@ class CautionaryAlertViewPageObject {
     endAlertButton =() => this.getByTestIdAttr("end-alert-button");
     endDateInput = () => this.getByTestIdAttr("end-date-input");
     confirmButton = () => this.getByTestIdAttr("confirm-button");
+    endDateInputError = () => this.getByTestIdAttr("end-date-error");
 
     // Details table items
     dateOfIncidentValue     = () => this.caTableItemValue("dateOfIncident");

--- a/cypress/pageObjects/CautionaryAlertViewPage.js
+++ b/cypress/pageObjects/CautionaryAlertViewPage.js
@@ -8,7 +8,9 @@ class CautionaryAlertViewPageObject {
     }
 
     // Specific UI items
-    pageTitle = () => cy.getByTestId("manage-ca-title");
+    pageTitle = () => this.getByTestIdAttr("manage-ca-title");
+    backLink = () => this.getByTestIdAttr("back-link");
+    closeButton =() => this.getByTestIdAttr("close-link");
 
     // Details table items
     dateOfIncidentValue     = () => this.caTableItemValue("dateOfIncident");
@@ -19,7 +21,8 @@ class CautionaryAlertViewPageObject {
     assureReferenceValue    = () => this.caTableItemValue("assureReference");
 
     // Reuse purpose
-    caTableItemValue = (itemName) => cy.getByTestId(`${itemName}-value`);
+    getByTestIdAttr  = (testName) => cy.getByTestId(testName)
+    caTableItemValue = (itemName) => this.getByTestIdAttr(`${itemName}-value`);
 }
 
 export default CautionaryAlertViewPageObject;

--- a/cypress/pageObjects/personPage.js
+++ b/cypress/pageObjects/personPage.js
@@ -150,5 +150,8 @@ class PersonPageObjects {
     personAlert() {
         return cy.get('.lbh-heading-h4 > .mtfh-icon');
     }
+    nthCautionaryAlert(number = 0) {
+        return cy.getByTestId(`cautionary-alert-link-${number}`);
+    }
 }
 export default PersonPageObjects

--- a/cypress/pageObjects/personPage.js
+++ b/cypress/pageObjects/personPage.js
@@ -11,6 +11,10 @@ class PersonPageObjects {
         // Needs a better selector
     }
 
+    pageTitle() {
+        return cy.get("[class='lbh-heading-h1']");
+    }
+
     headerContainerName() {
         return cy.get("[data-testid='person-fullName']")
     }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,3 +63,11 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 Cypress.Commands.add('getByTestId', (testName) => {
     cy.get(`[data-testid=${testName}]`)
 })
+
+Cypress.Commands.add('setUpEndAlertError', (alertId) => {
+    const cautionaryAlertEndpoint = Cypress.env('CAUTIONARY_ALERT_ENDPOINT');
+    cy.intercept(
+        { method: 'PATCH', url: `${cautionaryAlertEndpoint}/cautionary-alerts/alerts/${alertId}/end-alert` },
+        { statusCode: 500, headers: { 'access-control-allow-headers': 'content-type' } }
+      );
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,6 +33,10 @@ Cypress.Commands.add('getPersonFixture', () => {
     cy.readFile('cypress/fixtures/Persons.json')
 })
 
+Cypress.Commands.add('getCautionaryAlertFixture', () => {
+    cy.readFile('cypress/fixtures/CautionaryAlerts.json');
+});
+
 Cypress.Commands.add('getTenureFixture', () => {
     cy.readFile('cypress/fixtures/TenureInformation.json')
 })
@@ -54,4 +58,8 @@ Cypress.on('uncaught:exception', (err, runnable) => {
     // returning false here prevents Cypress from
     // failing the test
     return false
+})
+
+Cypress.Commands.add('getByTestId', (testName) => {
+    cy.get(`[data-testid=${testName}]`)
 })

--- a/environment-config.js
+++ b/environment-config.js
@@ -6,6 +6,7 @@ let personCommentsUrl = "comment/person"
 let tenureCommentsUrl="comment/tenure"
 let propertyCommentsUrl="comment/property"
 let startSoleToJointProcessUrl="processes/soletojoint/start/tenure"
+let alertPreviewUrl="cautionary-alerts/alert"
 
 let tenureUrl = "tenure"
 let rootComponentPort = "9000"
@@ -40,6 +41,7 @@ module.exports = {
     tenureCommentsUrl,
     propertyCommentsUrl,
     startSoleToJointProcessUrl,
+    alertPreviewUrl,
     baseUrl,
     tenureUrl,
     property,


### PR DESCRIPTION
# What:
 - A new tests suite for View/End Cautionary Alert page E2E tests.

# Why:
 - So we know it works end to end: from SSM to databases.

# Notes:
 - These tests should at no point be tagged with `@Production` flag. Most of the functionality introduced is write-dependent. Even the tests that plainly test the display, depend on the test Cautionary Alert existing, which gets created within the database. Unlike DynamoDB tables: Person, Asset, etc. the Cautionary Alert creation & edit is managed via an API, which does not have the DELETE functionality. As such, the created test CAs do not get deleted unlike the dynamo mocks. Storage-wise this is not an issue as these tests don't get run nowhere near often enough for it to be an issue. However, should despite the warning above the tests get run against the Prod environment _(which they aren't now)_ the test CAs would stay on that prod db. 
 - Avoiding the above seems to be a common practice within these e2e tests. Any time write access is involved, the tests don't seem to be tagged with `@Production` flag.