### PR TITLE
MR-698 - Added test for new Patches field added to Add Asset form

### DIFF
--- a/api/models/requests/createAssetModel.js
+++ b/api/models/requests/createAssetModel.js
@@ -69,7 +69,46 @@ const createAssetModel = {
       }
     ]
   },
-  "tenure": null
+}
+
+const getAssetWithNoTenure = (assetGuid, patch) => {
+  return {
+    "id": assetGuid,
+    "assetId": "0014062023",
+    "assetType": "Dwelling",
+    "parentAssetIds": "463f556b-fbe6-4216-84f3-99b64ccafe6b",
+    "isActive": true,
+    "assetLocation": {
+      "floorNo": "",
+      "totalBlockFloors": null,
+      "parentAssets": []
+    },
+    "assetAddress": {
+      "uprn": "00014579215",
+      "postPreamble": "",
+      "addressLine1": "12 Pitcairn House",
+      "addressLine2": "",
+      "addressLine3": "",
+      "addressLine4": "",
+      "postCode": "E9 6PT"
+    },
+    "assetManagement": {
+      "agent": "",
+      "areaOfficeName": "",
+      "isCouncilProperty": true,
+      "managingOrganisation": "London Borough of Hackney",
+      "isTMOManaged": false,
+      "managingOrganisationId": "c01e3146-e630-c2cd-e709-18ef57bf3724"
+    },
+    "assetCharacteristics": {
+      "numberOfBedrooms": null,
+      "numberOfLivingRooms": null,
+      "yearConstructed": "",
+      "windowType": "",
+      "numberOfLifts": null
+    },
+    "patches": [patch]
+  }
 }
 
 const asset = (patch) => {
@@ -82,5 +121,6 @@ const asset = (patch) => {
 
 module.exports = {
   asset,
-  createAssetModel
+  createAssetModel,
+  getAssetWithNoTenure
 }

--- a/api/models/requests/createAssetModel.js
+++ b/api/models/requests/createAssetModel.js
@@ -69,6 +69,7 @@ const createAssetModel = {
       }
     ]
   },
+  "tenure": null
 }
 
 const asset = (patch) => {

--- a/cypress/e2e/common/common.js
+++ b/cypress/e2e/common/common.js
@@ -32,12 +32,12 @@ import dynamoDb from "../../../cypress/e2e/common/DynamoDb";
 import { hasToggle } from "../../helpers/hasToggle";
 import { guid } from "../../helpers/commentText";
 import property from "../../../api/property";
-import {searchPersonResults} from "../../support/searchPersonResults";
-import {searchPropertyResults} from "../../support/searchPropertyResults";
+import { searchPersonResults } from "../../support/searchPersonResults";
+import { searchPropertyResults } from "../../support/searchPropertyResults";
 import DynamoDb from "./DynamoDb";
 
 import { patch } from "../../../api/models/requests/patchModel"
-import { asset } from "../../../api/models/requests/createAssetModel"
+import { asset, getAssetWithNoTenure } from "../../../api/models/requests/createAssetModel"
 import { person } from "../../../api/models/requests/createPersonModel"
 import { tenure } from "../../../api/models/requests/addTenureModel";
 import { cautionaryAlert } from "../../../api/models/requests/cautionaryAlertModel";
@@ -139,7 +139,7 @@ Given("I create a new person", () => {
 });
 
 
-Given("I create a new {string} tenure",  (tenureTypeCode) => {
+Given("I create a new {string} tenure", (tenureTypeCode) => {
   cy.log("Creating new tenure record").then(() => {
     return tenure.createTenure(tenureTypeCode).then((response) => {
       cy.log(`Tenure created!`);
@@ -237,13 +237,13 @@ And('I click on the breadcrumb', () => {
 })
 
 Then('I am taken to the search page', () => {
- // cy.url().should('contain', "search")
+  // cy.url().should('contain', "search")
   cy.findAllByText("Search Results");
 })
 
 And('I click on the view property button', () => {
-    //navigation.viewPropertyButton().click();
- // cy.get(':nth-child(10) > [data-layer="Content"]').click();
+  //navigation.viewPropertyButton().click();
+  // cy.get(':nth-child(10) > [data-layer="Content"]').click();
   cy.get(".lbh-heading-h2 > .govuk-link").click();
 });
 
@@ -321,15 +321,15 @@ Then(
   }
 );
 Then(
-    "search results are displayed by the best match {string}",
-    (searchTerm) => {
-      if (searchTerm === "guid") {
-        searchTerm = guid;
-      }
-      searchPage
-          .searchResults()
-          .contains(searchTerm.replace(/\s/g, ""), { matchCase: false });
+  "search results are displayed by the best match {string}",
+  (searchTerm) => {
+    if (searchTerm === "guid") {
+      searchTerm = guid;
     }
+    searchPage
+      .searchResults()
+      .contains(searchTerm.replace(/\s/g, ""), { matchCase: false });
+  }
 );
 
 Then("the default sort option is correct", () => {
@@ -356,8 +356,7 @@ And("have no detectable a11y violations", () => {
   function axeTerminalLog(violations) {
     cy.task(
       "log",
-      `${violations.length} accessibility violation${
-        violations.length === 1 ? "" : "s"
+      `${violations.length} accessibility violation${violations.length === 1 ? "" : "s"
       } ${violations.length === 1 ? "was" : "were"} detected`
     );
 
@@ -497,7 +496,7 @@ And("I am on the tenure page for {string}", (tenure) => {
   cy.url().should("include", tenure);
 });
 
-Then('the personal details are displayed on the sidebar' ,() => {
+Then('the personal details are displayed on the sidebar', () => {
   personPage.sidebar().contains('Date of birth')
   personPage.sidebar().contains('Phone 1')
   personPage.sidebar().contains('Email 1')
@@ -506,9 +505,9 @@ Then('the personal details are displayed on the sidebar' ,() => {
 
 // Create/edit person page
 Given("I create a person for tenure", () => {
-    cy.getTenureFixture().then((tenure) => {
-        addPersonPage.visit(tenure.id);
-    })
+  cy.getTenureFixture().then((tenure) => {
+    addPersonPage.visit(tenure.id);
+  })
 });
 
 And("I select a preferred middle name {string}", (preferredMiddleName) => {
@@ -563,7 +562,7 @@ Then('the add a new person tenure page is correct', () => {
 
 // Tenure page
 When('I view a tenure {string}', (id) => {
-  cy.getTenureFixture().then(({id: tenureId }) => {
+  cy.getTenureFixture().then(({ id: tenureId }) => {
     tenurePage.visit(id || tenureId)
   })
 })
@@ -591,7 +590,7 @@ And('the edit tenure button is not displayed', () => {
 
 // Property page
 Given("I create a new property", async () => {
-  const record = { tableName: "Assets", key: { id: "6f22e9ae-3e8a-4e0e-af46-db02eb87f8e6" }}
+  const record = { tableName: "Assets", key: { id: "6f22e9ae-3e8a-4e0e-af46-db02eb87f8e6" } }
   await dynamoDb.deleteRecordFromDynamoDB(record)
   cy.log("Creating Property record");
   const response = await property.createProperty();
@@ -602,7 +601,7 @@ Given("I create a new property", async () => {
 })
 
 Given("I create a new property {string}", async (type) => {
-  const record = { tableName: "Assets", key: { id: "6f22e9ae-3e8a-4e0e-af46-db02eb87f8e6" }}
+  const record = { tableName: "Assets", key: { id: "6f22e9ae-3e8a-4e0e-af46-db02eb87f8e6" } }
   await dynamoDb.deleteRecordFromDynamoDB(record)
   cy.log("Creating Property record");
   const response = await property.createProperty(type);
@@ -613,7 +612,7 @@ Given("I create a new property {string}", async (type) => {
 })
 
 Given("I create a new property with tenure", async () => {
-  const record = { tableName: "Assets", key: { id: "6f22e9ae-3e8a-4e0e-af46-db02eb87f8e6" }}
+  const record = { tableName: "Assets", key: { id: "6f22e9ae-3e8a-4e0e-af46-db02eb87f8e6" } }
   await dynamoDb.deleteRecordFromDynamoDB(record)
   cy.log("Creating Property record");
   const response = await property.createPropertyWithTenure();
@@ -623,7 +622,7 @@ Given("I create a new property with tenure", async () => {
   propertyId = response.data.id;
 })
 When("I view a property {string}", (id) => {
-  cy.getAssetFixture().then(({ id: propertyId}) => {
+  cy.getAssetFixture().then(({ id: propertyId }) => {
     propertyPage.visit(id || propertyId);
   })
 });
@@ -636,7 +635,7 @@ Then('the property information is displayed', () => {
 })
 
 Then('I am on the create new tenure page {string}', (id) => {
-  cy.getAssetFixture().then(({id: propertyId}) => {
+  cy.getAssetFixture().then(({ id: propertyId }) => {
     cy.url().should('contain', `tenure/${id || propertyId}/add`)
   })
 })
@@ -653,11 +652,11 @@ When('I click on the add new person to tenure button', () => {
 })
 
 And('I click the modal cancel button', () => {
-  modal.cancelButton().click({force: true})
+  modal.cancelButton().click({ force: true })
 })
 
 And('I click the confirm button', () => {
-  modal.confirmationButton().click({force: true})
+  modal.confirmationButton().click({ force: true })
 })
 
 Then('the cancel modal is displayed', () => {
@@ -676,17 +675,17 @@ And('I click yes on the modal', () => {
   modal.confirmationButton().click()
 })
 
-    // Add person
+// Add person
 And('I select a title {string}', (title) => {
   addPersonPage.personTitleSelection().select(title)
 })
 
 When('I select person type {string}', (personType) => {
-  if(personType === 'Named tenure holder') {
-      addPersonPage.tenureHolderRadioButton().click()
+  if (personType === 'Named tenure holder') {
+    addPersonPage.tenureHolderRadioButton().click()
   }
-  if(personType === 'Household member') {
-      addPersonPage.householdMemberRadioButton().click()
+  if (personType === 'Household member') {
+    addPersonPage.householdMemberRadioButton().click()
   }
 })
 
@@ -701,11 +700,11 @@ And('I enter a middle name {string}', (middleName) => {
 })
 
 And('I enter a last name {string}', (lastName) => {
-    if(lastName === 'guid') {
-        lastName = guid
-    }
-    addPersonPage.lastNameContainer().clear()
-    addPersonPage.lastNameContainer().type(lastName)
+  if (lastName === 'guid') {
+    lastName = guid
+  }
+  addPersonPage.lastNameContainer().clear()
+  addPersonPage.lastNameContainer().type(lastName)
 })
 
 And('I enter a date of birth {string} {string} {string}', (day, month, year) => {
@@ -760,7 +759,7 @@ When("I enter {string} as search criteria", (textSearch) => {
   changeOfNamePage.searchField().clear().type(textSearch);
 });
 When("I select {string} and click on search button", (entity) => {
-  switch (entity){
+  switch (entity) {
     case 'Person':
       changeOfNamePage.radiobuttonPerson().click();
       changeOfNamePage.searchButton().click();
@@ -798,7 +797,7 @@ When("I select person", () => {
             title = person.title + "."
           } else title = person.title;
           let fullname = title + " " + person.firstname + " " + person.surname;
-          cy.findByRole('link', {name: fullname}).click();
+          cy.findByRole('link', { name: fullname }).click();
           break;
         } else {
           i++;
@@ -820,7 +819,7 @@ When("I select person who is InActive", () => {
             title = person.title + "."
           } else title = person.title;
           let fullname = title + " " + person.firstname + " " + person.surname;
-          cy.findByRole('link', {name: fullname}).click();
+          cy.findByRole('link', { name: fullname }).click();
           break;
         } else {
           i++;
@@ -839,7 +838,7 @@ When("I select person and click on checkbox", () => {
         title = title + ".";
       }
       const fullname = `${title} ${person.firstname} ${person.surname}`;
-      cy.findByRole('link', {name: fullname}).click();
+      cy.findByRole('link', { name: fullname }).click();
       break;
     }
   });
@@ -860,7 +859,7 @@ When("I click on Save email address without entering any data", () => {
   cy.contains('Save email address').click();
 });
 Then("Validation error message is displayed for email address", () => {
-  cy.get('#contact-details-email-address-error').should('contain','You must enter an email address to proceed');
+  cy.get('#contact-details-email-address-error').should('contain', 'You must enter an email address to proceed');
 });
 When("I click on Save Phone number without entering any data", () => {
   cy.get('.mtfh-fieldset__content > :nth-child(2) > .govuk-button').click();
@@ -876,8 +875,8 @@ When("I click on the link 'the contact details'", () => {
 });
 
 Then("{string} modal dialog is displayed", (header) => {
-  modal.modalBody().should('contain',header);
-  modal.modalBody().should('contain','Add an email address');
+  modal.modalBody().should('contain', header);
+  modal.modalBody().should('contain', 'Add an email address');
   changeOfName.buttonReturnToApplication().should('exist');
 });
 When("I select Return to Application", () => {
@@ -897,40 +896,40 @@ When("I enter data email address and phone number", () => {
   cy.contains('Save phone number').click();
   changeOfName.buttonReturnToApplication().click();
 });
- And("I click on Remove email address and Remove phone number" , () => {
-   cy.get('[data-testid=button-remove-email]').click();
-   cy.get('[data-testid=button-confirm-remove-email]').click();
-   cy.get('[data-testid=button-remove-phone]').click();
-   cy.get('[data-testid=button-confirm-remove-phone]').click();
-   changeOfName.buttonReturnToApplication().click();
-// contactDetails.getContactDetails(personId).then(getResponse => {
-//   cy.log(`Status code ${getResponse.status} returned`)
-//   if (getResponse.status === 200) {
-//     const results = getResponse.data.results
-//     results.forEach(({id, targetId, contactInformation }) => {
-//       if (contactInformation.contactType === "phone") {
-//         cy.log(`id=${id}`)
-//         cy.log(`tid=${targetId}`)
-//         contactDetails.deleteContactDetails(
-//             id,
-//             targetId,
-//         ).then(deleteResponse => {
-//           assert.deepEqual(deleteResponse.status, 200)
-//
-//         })
-//       }
-//     })
+And("I click on Remove email address and Remove phone number", () => {
+  cy.get('[data-testid=button-remove-email]').click();
+  cy.get('[data-testid=button-confirm-remove-email]').click();
+  cy.get('[data-testid=button-remove-phone]').click();
+  cy.get('[data-testid=button-confirm-remove-phone]').click();
+  changeOfName.buttonReturnToApplication().click();
+  // contactDetails.getContactDetails(personId).then(getResponse => {
+  //   cy.log(`Status code ${getResponse.status} returned`)
+  //   if (getResponse.status === 200) {
+  //     const results = getResponse.data.results
+  //     results.forEach(({id, targetId, contactInformation }) => {
+  //       if (contactInformation.contactType === "phone") {
+  //         cy.log(`id=${id}`)
+  //         cy.log(`tid=${targetId}`)
+  //         contactDetails.deleteContactDetails(
+  //             id,
+  //             targetId,
+  //         ).then(deleteResponse => {
+  //           assert.deepEqual(deleteResponse.status, 200)
+  //
+  //         })
+  //       }
+  //     })
+  //   }
+  // })
+});
+// And("I click on Remove phone number" , () => {
+//   let phoneBtn = cy.get('[data-testid=button-remove-phone]');
+//   for(let i = 0; i < phoneBtn.length; i++) {
+//    phoneBtn[i].click();
+//     cy.get('[data-testid=button-confirm-remove-phone]').click();
 //   }
-// })
-  });
- // And("I click on Remove phone number" , () => {
- //   let phoneBtn = cy.get('[data-testid=button-remove-phone]');
- //   for(let i = 0; i < phoneBtn.length; i++) {
- //    phoneBtn[i].click();
- //     cy.get('[data-testid=button-confirm-remove-phone]').click();
- //   }
- //   changeOfName.buttonReturnToApplication().click();
- // });
+//   changeOfName.buttonReturnToApplication().click();
+// });
 
 Then("email address and phone number are null", () => {
   cy.contains(emailAdd).should('not.exist');
@@ -949,7 +948,7 @@ And("I can see the text add the contact details", () => {
   cy.contains('Please add the contact details, it will automatically update the tenant’s contact details as well.');
 });
 
-Given("I seeded the database",() => {
+Given("I seeded the database", () => {
   cy.log("Seeding database").then(() => {
     const patchModel = patch;
     const assetModel = asset(patchModel);
@@ -996,6 +995,85 @@ Given("I seeded the database",() => {
   })
 })
 
+Given("I seeded the database with an asset {string} with no attached tenure", (assetGuid) => {
+  cy.log("Seeding database").then(() => {
+    const patchModel = patch;
+    const assetModel = getAssetWithNoTenure(assetGuid, patchModel)
+    const personModel1 = person();
+    const personModel2 = person();
+    const tenureModel = tenure({}, assetModel, [personModel1, { isResponsible: true, personTenureType: "Tenant", ...personModel2 }]);
+
+    return new Cypress.Promise((resolve) => {
+      Promise.all([
+        DynamoDb.createRecord("PatchesAndAreas", patchModel),
+        DynamoDb.createRecord("Assets", assetModel),
+        DynamoDb.createRecord("Persons", personModel1),
+        DynamoDb.createRecord("Persons", personModel2),
+      ]).then(() => {
+        resolve()
+      })
+    }).then(() => {
+      cy.log("Database seeded!");
+    })
+  })
+})
+
+Given("I seeded the database with an asset {string} with a previous tenure", (assetGuid) => {
+  cy.log("Seeding database").then(() => {
+    const patchModel = patch;
+    const assetModel = getAssetWithNoTenure(assetGuid, patchModel)
+    const personModel1 = person();
+    const personModel2 = person();
+    const tenureModel = tenure({}, assetModel, [personModel1, { isResponsible: true, personTenureType: "Tenant", ...personModel2 }]);
+
+    const personTenure = {
+      id: tenureModel.id,
+      startDate: tenureModel.startOfTenureDate,
+      endDate: tenureModel.endOfTenureDate,
+      assetFullAddress: tenureModel.tenuredAsset.fullAddress,
+      assetId: tenureModel.tenuredAsset.id,
+      uprn: tenureModel.tenuredAsset.uprn,
+      isActive: false,
+      type: tenureModel.tenureType.description,
+      propertyReference: tenureModel.tenuredAsset.propertyReference,
+    }
+
+    personModel1.tenures.push(personTenure);
+    personModel2.tenures.push(personTenure);
+
+    assetModel.tenure = {
+      endOfTenureDate: tenureModel.endOfTenureDate,
+      id: tenureModel.id,
+      paymentReference: tenureModel.paymentReference,
+      startOfTenureDate: tenureModel.startOfTenureDate,
+      type: tenureModel.tenureType.description,
+    }
+
+    // Add expired/previous tenure to asset
+    assetModel.tenure = {
+      endOfTenureDate: "2022-07-29T00:00:00",
+      id: tenureModel.id,
+      paymentReference: tenureModel.paymentReference,
+      startOfTenureDate: "2020-07-29T00:00:00",
+      type: tenureModel.tenureType.description,
+    }
+
+    return new Cypress.Promise((resolve) => {
+      Promise.all([
+        DynamoDb.createRecord("PatchesAndAreas", patchModel),
+        DynamoDb.createRecord("Assets", assetModel),
+        DynamoDb.createRecord("TenureInformation", tenureModel),
+        DynamoDb.createRecord("Persons", personModel1),
+        DynamoDb.createRecord("Persons", personModel2),
+      ]).then(() => {
+        resolve()
+      })
+    }).then(() => {
+      cy.log("Database seeded!");
+    })
+  })
+})
+
 Given("There's a person with a cautionary alert", () => {
   cy
     .log("Creating cautoinary alert & entities associated with it")
@@ -1007,7 +1085,7 @@ Given("There's a person with a cautionary alert", () => {
       const personTenure = tenureToPersonTenure(tenureModel);
       personModel.tenures.push(personTenure);
       assetModel.tenure = tenureToAssetTenure(tenureModel);
-  
+
       const saveNonDynamoRecord = (response) => new Promise((resolve, reject) => {
         console.log("saveNonDynamoRecord data: ", response)
         try {
@@ -1016,16 +1094,16 @@ Given("There's a person with a cautionary alert", () => {
             [response.body],
             response,
           ).then((response) => {
-              resolve(response)
+            resolve(response)
           });
         }
-        catch(ex) {
+        catch (ex) {
           reject(ex);
         }
       });
 
       const cautionaryAlertRecord = cautionaryAlert(personModel, assetModel);
-      
+
       createCautionaryAlert(cautionaryAlertRecord).then((data) => {
         saveNonDynamoRecord(data).then((moreData) => {
           Promise.resolve(moreData);
@@ -1033,17 +1111,17 @@ Given("There's a person with a cautionary alert", () => {
       });
 
       return new Cypress.Promise((resolve) => {
-          Promise.all([
-            DynamoDb.createRecord("PatchesAndAreas", patchModel),
-            DynamoDb.createRecord("Assets", assetModel),
-            DynamoDb.createRecord("TenureInformation", tenureModel),
-            DynamoDb.createRecord("Persons", personModel)
-          ]).then(() => {
-            resolve();
-          });
-        }).then(() => {
-          cy.log("CA related data created.");
-        })
+        Promise.all([
+          DynamoDb.createRecord("PatchesAndAreas", patchModel),
+          DynamoDb.createRecord("Assets", assetModel),
+          DynamoDb.createRecord("TenureInformation", tenureModel),
+          DynamoDb.createRecord("Persons", personModel)
+        ]).then(() => {
+          resolve();
+        });
+      }).then(() => {
+        cy.log("CA related data created.");
+      })
     });
 });
 
@@ -1066,17 +1144,55 @@ Given("I create a tenure {string} {string}", (startOfTenureDate, isResponsible) 
 })
 
 After(() => {
-    const filename = "cypress/fixtures/recordsToDelete.json";
-    cy.readFile(filename)
-      .then(data => {
+  const filename = "cypress/fixtures/recordsToDelete.json";
+  cy.readFile(filename)
+    .then(data => {
+      return new Cypress.Promise((resolve) => {
+        Promise.all(data.map(record => dynamoDb.deleteRecord(record)))
+          .then(() => {
+            resolve()
+          })
+      }).then(() => {
+        cy.writeFile(filename, []);
+        cy.log("Test database records cleared!")
+      })
+    });
+})
+
+beforeEach(() => {
+  const filename = "cypress/fixtures/recordsToDelete.json";
+  cy.readFile(filename)
+    .then(recordsToDelete => {
+      if (recordsToDelete.length) {
+
         return new Cypress.Promise((resolve) => {
-          Promise.all(data.map(record => dynamoDb.deleteRecord(record)))
+          Promise.all(recordsToDelete.map(record => dynamoDb.deleteRecord(record)))
             .then(() => {
               resolve()
             })
         }).then(() => {
           cy.writeFile(filename, []);
-          cy.log("Database cleared!")
+          cy.log("Test database records cleared!")
         })
+      }
     });
-})
+});
+
+afterEach(() => {
+  const filename = "cypress/fixtures/recordsToDelete.json";
+  cy.readFile(filename)
+    .then(recordsToDelete => {
+      if (recordsToDelete.length) {
+
+        return new Cypress.Promise((resolve) => {
+          Promise.all(recordsToDelete.map(record => dynamoDb.deleteRecord(record)))
+            .then(() => {
+              resolve()
+            })
+        }).then(() => {
+          cy.writeFile(filename, []);
+          cy.log("Test database records cleared!")
+        })
+      }
+    });
+});

--- a/cypress/e2e/createTenure.feature
+++ b/cypress/e2e/createTenure.feature
@@ -10,536 +10,537 @@ Feature: Create tenure
   Background:
     Given I am logged in
 
-#  commented the below as its failing in Dev - record not found in Dev
-#  @ignore
-#  Scenario Outline: Clean up test data from DynamoDb
-#    Then I can delete a created record from DynamoDb "<tableName>"
-#
-#    Examples:
-#      | tableName          |
-#      | TenureInformation  |
-#
-  @ignore
-  @SmokeTest
-  Scenario Outline: Create new tenure
-    When I view a property "<property>"
-    When I click on the new tenure button
-    Then I am on the create new tenure page "<property>"
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
+  #  commented the below as its failing in Dev - record not found in Dev
+  #  @ignore
+  #  Scenario Outline: Clean up test data from DynamoDb
+  #    Then I can delete a created record from DynamoDb "<tableName>"
+  #
+  #    Examples:
+  #      | tableName          |
+  #      | TenureInformation  |
+  #
+  # TEMPORARILY COMMENTED OUT FROM LINE 23 TO LINE 543 (SOME TESTS HAD ALREADY BEEN COMMENTED OUT, SO THEY'LL HAVE TO "##" NOW)
+  #   @ignore
+  #   @SmokeTest
+  #   Scenario Outline: Create new tenure
+  #     When I view a property "<property>"
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page "<property>"
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
 
-    Examples:
-        | property                             | tenureType | startDay | startMonth | startYear |
-        | 05f2a78d-bc9d-255d-0c1c-98e7add1ca95 | Non-Secure   | 01       | 01         | 2000      |
-     #   | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      |
+  #     Examples:
+  #         | property                             | tenureType | startDay | startMonth | startYear |
+  #         | 05f2a78d-bc9d-255d-0c1c-98e7add1ca95 | Non-Secure   | 01       | 01         | 2000      |
+  #      #   | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      |
 
-@ignore
-  @SmokeTest
-  Scenario Outline: Create new tenure search and select existing resident to add to the new tenure
-  #Then I can delete a created record from DynamoDb "<tableName>"
-    When I view a property "<property>"
-    When I click on the new tenure button
-    Then I am on the create new tenure page "<property>"
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
-    When I enter any of the following criteria "<searchTerm>"
-    And I click on the search button
-    Then the search results are displayed by best match "<searchTerm>"
-    When I add 1 named tenure holder
-    Then the person is added to the tenure
-  #Then I can delete a created record from DynamoDb "<tableName>"
-      ###   The below 2 steps are throwing an error in UI when adding the same person as householder member'The person is already added'
-#    When I add 1 household member
-#    Then the person is added to the tenure
-#    And I click done button
-#    Then the message New tenure completed is displayed
-#    Then the tenure information is displayed
+  # @ignore
+  #   @SmokeTest
+  #   Scenario Outline: Create new tenure search and select existing resident to add to the new tenure
+  #   #Then I can delete a created record from DynamoDb "<tableName>"
+  #     When I view a property "<property>"
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page "<property>"
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
+  #     When I enter any of the following criteria "<searchTerm>"
+  #     And I click on the search button
+  #     Then the search results are displayed by best match "<searchTerm>"
+  #     When I add 1 named tenure holder
+  #     Then the person is added to the tenure
+  #   #Then I can delete a created record from DynamoDb "<tableName>"
+  #       ###   The below 2 steps are throwing an error in UI when adding the same person as householder member'The person is already added'
+  # #    When I add 1 household member
+  # #    Then the person is added to the tenure
+  # #    And I click done button
+  # #    Then the message New tenure completed is displayed
+  # #    Then the tenure information is displayed
 
-    Examples:
-        | property                             | tenureType | startDay | startMonth | startYear | searchTerm |tableName          |
-        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 21       | 05         | 2022      | tre        |TenureInformation  |
+  #     Examples:
+  #         | property                             | tenureType | startDay | startMonth | startYear | searchTerm |tableName          |
+  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 21       | 05         | 2022      | tre        |TenureInformation  |
 
-  @ignore
-    @SmokeTest
-  Scenario Outline: Create new tenure search and select resident
-    When I view a property "<property>"
-    When I click on the new tenure button
-    Then I am on the create new tenure page "<property>"
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
-    When I enter any of the following criteria "<searchTerm>"
-    And I click on the search button
-    Then the search results are displayed by best match "<searchTerm>"
-    When I add 1 named tenure holder
-    Then the person is added to the tenure
-    When I add 1 household member
-    Then the person is added to the tenure
-    And I click done button
-    Then the message New tenure completed is displayed
-    Then the tenure information is displayed
+  #   @ignore
+  #     @SmokeTest
+  #   Scenario Outline: Create new tenure search and select resident
+  #     When I view a property "<property>"
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page "<property>"
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
+  #     When I enter any of the following criteria "<searchTerm>"
+  #     And I click on the search button
+  #     Then the search results are displayed by best match "<searchTerm>"
+  #     When I add 1 named tenure holder
+  #     Then the person is added to the tenure
+  #     When I add 1 household member
+  #     Then the person is added to the tenure
+  #     And I click done button
+  #     Then the message New tenure completed is displayed
+  #     Then the tenure information is displayed
 
-    Examples:
-      | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
-      | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
+  #     Examples:
+  #       | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
+  #       | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
 
-  @ignore
-  Scenario Outline: Create new tenure and filter search
-    When I view a property "<property>"
-    When I click on the new tenure button
-    Then I am on the create new tenure page "<property>"
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
-    When I enter any of the following criteria "<searchTerm>"
-    And I click on the search button
-    Then the search results are displayed by best match "<searchTerm>"
-    Then the default sort option is correct
-    When I select to sort by "<filter>"
-    When I set the number of results to <results>
-    Then the correct number of <results> are displayed
+  #   @ignore
+  #   Scenario Outline: Create new tenure and filter search
+  #     When I view a property "<property>"
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page "<property>"
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
+  #     When I enter any of the following criteria "<searchTerm>"
+  #     And I click on the search button
+  #     Then the search results are displayed by best match "<searchTerm>"
+  #     Then the default sort option is correct
+  #     When I select to sort by "<filter>"
+  #     When I set the number of results to <results>
+  #     Then the correct number of <results> are displayed
 
-    Examples:
-        | property                             | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
-        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
-        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
-        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
+  #     Examples:
+  #         | property                             | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
+  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
+  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
+  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
 
-  @SmokeTest
-  Scenario Outline: Create new tenure
-    Given I seeded the database
-    When I view a property ""
-    When I click on the new tenure button
-    Then I am on the create new tenure page ""
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
+  #   @SmokeTest
+  #   Scenario Outline: Create new tenure
+  #     Given I seeded the database
+  #     When I view a property ""
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page ""
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
 
-    Examples:
-      | tenureType | startDay | startMonth | startYear |
-      | Non-Secure   | 01       | 01         | 2000      |
+  #     Examples:
+  #       | tenureType | startDay | startMonth | startYear |
+  #       | Non-Secure   | 01       | 01         | 2000      |
 
-  @SmokeTest
-  Scenario Outline: Create new tenure search and select resident
-    Given I seeded the database
-    When I view a property ""
-    When I click on the new tenure button
-    Then I am on the create new tenure page ""
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
-    When I enter any of the following criteria "<searchTerm>"
-    And I click on the search button
-    Then the search results are displayed by best match "<searchTerm>"
-    When I add 1 named tenure holder
-    Then the person is added to the tenure
-    When I enter any of the following criteria "<searchTerm2>"
-    And I click on the search button
-    When I add 1 household member
-    Then the person is added to the tenure
-    And I click done button
-    Then the message New tenure completed is displayed
-    Then the tenure information is displayed
+  #   @SmokeTest
+  #   Scenario Outline: Create new tenure search and select resident
+  #     Given I seeded the database
+  #     When I view a property ""
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page ""
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
+  #     When I enter any of the following criteria "<searchTerm>"
+  #     And I click on the search button
+  #     Then the search results are displayed by best match "<searchTerm>"
+  #     When I add 1 named tenure holder
+  #     Then the person is added to the tenure
+  #     When I enter any of the following criteria "<searchTerm2>"
+  #     And I click on the search button
+  #     When I add 1 household member
+  #     Then the person is added to the tenure
+  #     And I click done button
+  #     Then the message New tenure completed is displayed
+  #     Then the tenure information is displayed
 
-    Examples:
-      | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
-      | Freehold   | 01       | 01         | 2000      | tre        | sar         |
+  #     Examples:
+  #       | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
+  #       | Freehold   | 01       | 01         | 2000      | tre        | sar         |
 
-  Scenario Outline: Create new tenure and filter search
-    Given I seeded the database
-    When I view a property ""
-    When I click on the new tenure button
-    Then I am on the create new tenure page ""
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    And the tenure person search is displayed
-    When I enter any of the following criteria "<searchTerm>"
-    And I click on the search button
-    Then the search results are displayed by best match "<searchTerm>"
-    Then the default sort option is correct
-    When I select to sort by "<filter>"
-    When I set the number of results to <results>
-    Then the correct number of <results> are displayed
+  #   Scenario Outline: Create new tenure and filter search
+  #     Given I seeded the database
+  #     When I view a property ""
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page ""
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     And the tenure person search is displayed
+  #     When I enter any of the following criteria "<searchTerm>"
+  #     And I click on the search button
+  #     Then the search results are displayed by best match "<searchTerm>"
+  #     Then the default sort option is correct
+  #     When I select to sort by "<filter>"
+  #     When I set the number of results to <results>
+  #     Then the correct number of <results> are displayed
 
-    Examples:
-      | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
-      | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
-      | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
-      | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
+  #     Examples:
+  #       | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
+  #       | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
+  #       | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
+  #       | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
 
-#  @ignore
-#  Scenario Outline: Create new tenure and add new person
-#    Given I create a new property
-#    When I view a property ""
-#    When I click on the new tenure button
-#    Then I am on the create new tenure page ""
-#    Then the new tenure landing page is displayed
-#    When I select a tenure type "<tenureType>"
-#    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-#    And I click the next button
-#    And the tenure person search is displayed
-#    And the create new person button is not enabled
-#    When I enter any of the following criteria "<searchTerm>"
-#    And I click on the search button
-#    And I click create new person
-#    And I am on the create new person for a new tenure page
-#    When I select person type "<personType>"
-#    And I select a title "<title>"
-#    And I enter a first name "<firstName>"
-#    And I enter a middle name "<middleName>"
-#    And I enter a last name "<lastName>"
-#    And I enter a date of birth "<day>" "<month>" "<year>"
-#    And I enter a place of birth "<placeOfBirth>"
-#    And I select a preferred title "<preferredTitle>"
-#    And I select a preferred first name "<preferredFirstName>"
-#    And I select a preferred middle name "<preferredMiddleName>"
-#    And I select a preferred last name "<preferredLastName>"
-#    And I enter a reason for creation
-#    And I click add person
-#    Then the person is added to the tenure
-#    And I am on the create contact for a new tenure page
-#    Then I click the add email address button
-#    And I enter an email address "<email>"
-#    And I enter an email description "<emailDescription>"
-#    And I click save email address
-#    And the email information is captured "<email>" "<emailDescription>"
-#    And I click the add phone number button
-#    And I enter a phone number "<phoneNumber>"
-#    And I select a phone number type "<phoneType>"
-#    And I enter a phone number description "<phoneDescription>"
-#    And I click save phone number
-#    And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
-#    And I click the next button
-#    And I click the save equality information button
-#    And the person is added to the list of tenures "<title>" "<firstName>" "<middleName>" "<lastName>" "<day>" "<month>" "<year>"
-#    And the tenure person search is displayed
-#
-#        Examples:
-#        | property                             | tenureType | startDay | startMonth | startYear | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
-#        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
-#
-#  @ignore
-#  Scenario Outline: Create new tenure validation
-#    Given I create a new property
-#    When I view a property ""
-#    When I click on the new tenure button
-#    Then I am on the create new tenure page ""
-#    Then the new tenure landing page is displayed
-#    When I select a tenure type "<tenureType>"
-#    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-#    And I click the next button
-#    And the tenure person search is displayed
-#    When I enter any of the following criteria "<searchTerm>"
-#    And I click on the search button
-#    Then the search results are displayed by best match "<searchTerm>"
-#    When I add 1 named tenure holder
-#    Then the person is added to the tenure
-#    When I add 1 named tenure holder
-#    Then a new tenure error message appears "The person is already added"
-#    When I enter any of the following criteria "<searchTerm2>"
-#    And I click on the search button
-#    When I add 1 household member
-#    Then the person is added to the tenure
-#    When I add 1 household member
-#    Then a new tenure error message appears "The person is already added"
-#    When I add 5 named tenure holder
-#    Then a new tenure error message appears "Max. tenure holders added"
-#
-#    Examples:
-#        | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
-#        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
-#
-#  @ignore
-#  @SmokeTest
-#  Scenario Outline: Create new tenure and cancel
-#    When I view a property "<property>"
-#    When I click on the new tenure button
-#    Then I am on the create new tenure page "<property>"
-#    Then the new tenure landing page is displayed
-#    And I click the cancel button
-#    Then the cancel confirmation modal is displayed
-#    And I click the modal cancel button
-#    Then the new tenure landing page is displayed
-#    And I click the cancel button
-#    Then the cancel confirmation modal is displayed
-#    And I click the confirm button
-#    Then the property information is displayed
-#
-#    Examples:
-#        | property                             |
-#        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 |
-#
-#  @SmokeTest
-#  Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
-#    When I view a property "<property>"
-#    When I click on the new tenure button
-#    Then I am on the create new tenure page "<property>"
-#    Then the new tenure landing page is displayed
-#    When I select a tenure type "<tenureType>"
-#    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-#    And I click the next button
-#    Then a create tenure error is triggered
-#
-#    Examples:
-#        | property                             | tenureType | startDay | startMonth | startYear |
-#        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Freehold   | 01       | 01         | 1900      |
-#
-#  @SmokeTest
-#  Scenario Outline: Create new tenure that with start date that occurs after end date
-#    When I view a property "<property>"
-#    When I click on the new tenure button
-#    Then I am on the create new tenure page "<property>"
-#    Then the new tenure landing page is displayed
-#    When I select a tenure type "<tenureType>"
-#    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-#    And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
-#    And I click the next button
-#    Then a create tenure error is triggered
-#
-#    Examples:
-#        | property                             | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
-#        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
-#
-#  @ignore
-#  Scenario Outline: Edit existing tenure
-#        When I view a Tenure "<tenure>"
-#        Then the tenure information is displayed
-#        And I click edit tenure
-#        Then the edit tenure information is displayed
-#        When I select a tenure type "<tenureType>"
-#        And I click done button
-#        Then the edit tenure information is displayed "<tenure>"
-#
-#        Examples:
-#        | tenure                               | tenureType |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
-#        # | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure     |
-#
-#    Scenario Outline: Edit existing tenure and cancel
-#        When I view a Tenure "<tenure>"
-#        Then the tenure information is displayed
-#        And I click edit tenure
-#        Then the edit tenure information is displayed
-#        When I select a tenure type "<tenureType>"
-#        And I click the cancel button
-#        Then the cancel modal is displayed
-#        When I click cancel on the modal
-#        Then the edit tenure information is displayed
-#        And I click the cancel button
-#        Then the cancel modal is displayed
-#        And I click yes on the modal
-#        Then the tenure information is displayed
-#
-#        Examples:
-#        | tenure                               | tenureType |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
+  # #  @ignore
+  # #  Scenario Outline: Create new tenure and add new person
+  # #    Given I create a new property
+  # #    When I view a property ""
+  # #    When I click on the new tenure button
+  # #    Then I am on the create new tenure page ""
+  # #    Then the new tenure landing page is displayed
+  # #    When I select a tenure type "<tenureType>"
+  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  # #    And I click the next button
+  # #    And the tenure person search is displayed
+  # #    And the create new person button is not enabled
+  # #    When I enter any of the following criteria "<searchTerm>"
+  # #    And I click on the search button
+  # #    And I click create new person
+  # #    And I am on the create new person for a new tenure page
+  # #    When I select person type "<personType>"
+  # #    And I select a title "<title>"
+  # #    And I enter a first name "<firstName>"
+  # #    And I enter a middle name "<middleName>"
+  # #    And I enter a last name "<lastName>"
+  # #    And I enter a date of birth "<day>" "<month>" "<year>"
+  # #    And I enter a place of birth "<placeOfBirth>"
+  # #    And I select a preferred title "<preferredTitle>"
+  # #    And I select a preferred first name "<preferredFirstName>"
+  # #    And I select a preferred middle name "<preferredMiddleName>"
+  # #    And I select a preferred last name "<preferredLastName>"
+  # #    And I enter a reason for creation
+  # #    And I click add person
+  # #    Then the person is added to the tenure
+  # #    And I am on the create contact for a new tenure page
+  # #    Then I click the add email address button
+  # #    And I enter an email address "<email>"
+  # #    And I enter an email description "<emailDescription>"
+  # #    And I click save email address
+  # #    And the email information is captured "<email>" "<emailDescription>"
+  # #    And I click the add phone number button
+  # #    And I enter a phone number "<phoneNumber>"
+  # #    And I select a phone number type "<phoneType>"
+  # #    And I enter a phone number description "<phoneDescription>"
+  # #    And I click save phone number
+  # #    And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
+  # #    And I click the next button
+  # #    And I click the save equality information button
+  # #    And the person is added to the list of tenures "<title>" "<firstName>" "<middleName>" "<lastName>" "<day>" "<month>" "<year>"
+  # #    And the tenure person search is displayed
+  # #
+  # #        Examples:
+  # #        | property                             | tenureType | startDay | startMonth | startYear | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
+  # #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
+  # #
+  # #  @ignore
+  # #  Scenario Outline: Create new tenure validation
+  # #    Given I create a new property
+  # #    When I view a property ""
+  # #    When I click on the new tenure button
+  # #    Then I am on the create new tenure page ""
+  # #    Then the new tenure landing page is displayed
+  # #    When I select a tenure type "<tenureType>"
+  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  # #    And I click the next button
+  # #    And the tenure person search is displayed
+  # #    When I enter any of the following criteria "<searchTerm>"
+  # #    And I click on the search button
+  # #    Then the search results are displayed by best match "<searchTerm>"
+  # #    When I add 1 named tenure holder
+  # #    Then the person is added to the tenure
+  # #    When I add 1 named tenure holder
+  # #    Then a new tenure error message appears "The person is already added"
+  # #    When I enter any of the following criteria "<searchTerm2>"
+  # #    And I click on the search button
+  # #    When I add 1 household member
+  # #    Then the person is added to the tenure
+  # #    When I add 1 household member
+  # #    Then a new tenure error message appears "The person is already added"
+  # #    When I add 5 named tenure holder
+  # #    Then a new tenure error message appears "Max. tenure holders added"
+  # #
+  # #    Examples:
+  # #        | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
+  # #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
+  # #
+  # #  @ignore
+  # #  @SmokeTest
+  # #  Scenario Outline: Create new tenure and cancel
+  # #    When I view a property "<property>"
+  # #    When I click on the new tenure button
+  # #    Then I am on the create new tenure page "<property>"
+  # #    Then the new tenure landing page is displayed
+  # #    And I click the cancel button
+  # #    Then the cancel confirmation modal is displayed
+  # #    And I click the modal cancel button
+  # #    Then the new tenure landing page is displayed
+  # #    And I click the cancel button
+  # #    Then the cancel confirmation modal is displayed
+  # #    And I click the confirm button
+  # #    Then the property information is displayed
+  # #
+  # #    Examples:
+  # #        | property                             |
+  # #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 |
+  # #
+  # #  @SmokeTest
+  # #  Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
+  # #    When I view a property "<property>"
+  # #    When I click on the new tenure button
+  # #    Then I am on the create new tenure page "<property>"
+  # #    Then the new tenure landing page is displayed
+  # #    When I select a tenure type "<tenureType>"
+  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  # #    And I click the next button
+  # #    Then a create tenure error is triggered
+  # #
+  # #    Examples:
+  # #        | property                             | tenureType | startDay | startMonth | startYear |
+  # #        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Freehold   | 01       | 01         | 1900      |
+  # #
+  # #  @SmokeTest
+  # #  Scenario Outline: Create new tenure that with start date that occurs after end date
+  # #    When I view a property "<property>"
+  # #    When I click on the new tenure button
+  # #    Then I am on the create new tenure page "<property>"
+  # #    Then the new tenure landing page is displayed
+  # #    When I select a tenure type "<tenureType>"
+  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  # #    And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
+  # #    And I click the next button
+  # #    Then a create tenure error is triggered
+  # #
+  # #    Examples:
+  # #        | property                             | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
+  # #        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
+  # #
+  # #  @ignore
+  # #  Scenario Outline: Edit existing tenure
+  # #        When I view a Tenure "<tenure>"
+  # #        Then the tenure information is displayed
+  # #        And I click edit tenure
+  # #        Then the edit tenure information is displayed
+  # #        When I select a tenure type "<tenureType>"
+  # #        And I click done button
+  # #        Then the edit tenure information is displayed "<tenure>"
+  # #
+  # #        Examples:
+  # #        | tenure                               | tenureType |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
+  # #        # | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure     |
+  # #
+  # #    Scenario Outline: Edit existing tenure and cancel
+  # #        When I view a Tenure "<tenure>"
+  # #        Then the tenure information is displayed
+  # #        And I click edit tenure
+  # #        Then the edit tenure information is displayed
+  # #        When I select a tenure type "<tenureType>"
+  # #        And I click the cancel button
+  # #        Then the cancel modal is displayed
+  # #        When I click cancel on the modal
+  # #        Then the edit tenure information is displayed
+  # #        And I click the cancel button
+  # #        Then the cancel modal is displayed
+  # #        And I click yes on the modal
+  # #        Then the tenure information is displayed
+  # #
+  # #        Examples:
+  # #        | tenure                               | tenureType |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
 
-#
-#  Scenario Outline: Display Confirmation Alert pop up when ending a Tenure
-#    When I view a Tenure "<tenure>"
-#    Then the tenure information is displayed
-#    And I click edit tenure
-#    Then the edit tenure information is displayed
-#    When I select a tenure type "<tenureType>"
-#    And I enter a tenure end date as "<day>" "<month>" "<year>"
-#    And I click the next button
-#    Then the warning modal is displayed
-#    And the information text is displayed
-#    When I click cancel on the modal
-#    Then the edit tenure information is displayed
-#    # When the below steps are executed the test data will be unvailable for the next run as edit tenure button will not be displayed
-#    #When I click yes on the modal
-#    #Then the tenure information is displayed with the page heading Tenure updated
-#
-#    Examples:
-#      | tenure                               | tenureType | day | month | year |
-#      | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |  20 |  05   | 2022 |
-#
-#    Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
-#        When I view a Tenure "<tenure>"
-#        Then the tenure information is displayed
-#        And the edit tenure button is not displayed
-#        Examples:
-#        | tenure                               |
-#        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
-#
-#    Scenario Outline: Cannot edit tenure for inactive or past tenures
-#        When I edit a Tenure "<tenure>"
-#        Then the tenure cannot be edited warning message is displayed
-#
-#        Examples:
-#        | tenure                               |
-#        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
-#
-#    @ignore
-#    Scenario Outline: Create person by navigating to new tenure
-#        Given I delete all existing persons from the tenure "<tenure>"
-#        When I navigate to a create person for new tenure "<property>" "<tenure>"
-#        And the tenure person search is displayed
-#        And the create new person button is not enabled
-#        When I enter any of the following criteria "<searchTerm>"
-#        And I click on the search button
-#        And I click create new person
-#        And I am on the create new person for a new tenure page
-#        When I select person type "<personType>"
-#        And I select a title "<title>"
-#        And I enter a first name "<firstName>"
-#        And I enter a middle name "<middleName>"
-#        And I enter a last name "<lastName>"
-#        And I enter a date of birth "<day>" "<month>" "<year>"
-#        And I enter a place of birth "<placeOfBirth>"
-#        And I select a preferred title "<preferredTitle>"
-#        And I select a preferred first name "<preferredFirstName>"
-#        And I select a preferred middle name "<preferredMiddleName>"
-#        And I select a preferred last name "<preferredLastName>"
-#        And I enter a reason for creation
-#        And I click add person
-#        Then I am on the create contact for a new tenure page
-#        And I click the add email address button
-#        And I enter an email address "<email>"
-#        And I enter an email description "<emailDescription>"
-#        And I click save email address
-#        And the email information is captured "<email>" "<emailDescription>"
-#        And I click the add phone number button
-#        And I enter a phone number "<phoneNumber>"
-#        And I select a phone number type "<phoneType>"
-#        And I enter a phone number description "<phoneDescription>"
-#        And I click save phone number
-#        And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
-#        And I click done button
-#        And the tenure person search is displayed
-#
-#        Examples:
-#        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
-#        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
-#
-#
-#    @ignore
-#    Scenario Outline: Create person for new tenure validation
-#        Given I delete all existing persons from the tenure "<tenure>"
-#        When I navigate to a create person for new tenure "<property>" "<tenure>"
-#        When I enter any of the following criteria "<searchTerm>"
-#        And I click on the search button
-#        When I add 5 named tenure holder
-#        Then a new tenure error message appears "Max. tenure holders added"
-#        And I click create new person
-#        And I am on the create new person for a new tenure page
-#        And the named tenure holder button is not active
-#        And I remove one of the tenure holders
-#        And I click the cancel button
-#        And I remove one of the tenure holders
-#        And I click remove person
-#        Then the person is removed
-#        When I select person type "Named tenure holder"
-#        And I select a title "<title>"
-#        And I enter a first name "<firstName>"
-#        And I enter a last name "<lastName>"
-#        And I enter a date of birth "<day>" "<month>" "<year>"
-#        And I enter a reason for creation
-#        And I click done button
-#
-#        Examples:
-#        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
-#        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
-#
-#    @regression
-#    Scenario Outline: End dates are editable for all tenure types
-#      When I edit a Tenure "<tenure>"
-#      When I select a tenure type "<tenureType>"
-#      Then the tenure end date is editable
-#
-#      Examples:
-#        | tenure                               | tenureType       |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold         |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold (Serv)  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Introductory     |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Leasehold (RTB)  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | License Temp Ac  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Lse 100% Stair   |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Mesne Profit Ac  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Non-Secure       |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Private Sale LH  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Rent To Mortgage |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure           |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Equity    |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Owners    |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Short Life Lse   |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Annex       |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp B&B         |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Decant      |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel      |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel Lse  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Private Lt  |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Traveller   |
-#        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Tenant Acc Flat  |
+  # #
+  # #  Scenario Outline: Display Confirmation Alert pop up when ending a Tenure
+  # #    When I view a Tenure "<tenure>"
+  # #    Then the tenure information is displayed
+  # #    And I click edit tenure
+  # #    Then the edit tenure information is displayed
+  # #    When I select a tenure type "<tenureType>"
+  # #    And I enter a tenure end date as "<day>" "<month>" "<year>"
+  # #    And I click the next button
+  # #    Then the warning modal is displayed
+  # #    And the information text is displayed
+  # #    When I click cancel on the modal
+  # #    Then the edit tenure information is displayed
+  # #    # When the below steps are executed the test data will be unvailable for the next run as edit tenure button will not be displayed
+  # #    #When I click yes on the modal
+  # #    #Then the tenure information is displayed with the page heading Tenure updated
+  # #
+  # #    Examples:
+  # #      | tenure                               | tenureType | day | month | year |
+  # #      | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |  20 |  05   | 2022 |
+  # #
+  # #    Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
+  # #        When I view a Tenure "<tenure>"
+  # #        Then the tenure information is displayed
+  # #        And the edit tenure button is not displayed
+  # #        Examples:
+  # #        | tenure                               |
+  # #        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+  # #
+  # #    Scenario Outline: Cannot edit tenure for inactive or past tenures
+  # #        When I edit a Tenure "<tenure>"
+  # #        Then the tenure cannot be edited warning message is displayed
+  # #
+  # #        Examples:
+  # #        | tenure                               |
+  # #        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+  # #
+  # #    @ignore
+  # #    Scenario Outline: Create person by navigating to new tenure
+  # #        Given I delete all existing persons from the tenure "<tenure>"
+  # #        When I navigate to a create person for new tenure "<property>" "<tenure>"
+  # #        And the tenure person search is displayed
+  # #        And the create new person button is not enabled
+  # #        When I enter any of the following criteria "<searchTerm>"
+  # #        And I click on the search button
+  # #        And I click create new person
+  # #        And I am on the create new person for a new tenure page
+  # #        When I select person type "<personType>"
+  # #        And I select a title "<title>"
+  # #        And I enter a first name "<firstName>"
+  # #        And I enter a middle name "<middleName>"
+  # #        And I enter a last name "<lastName>"
+  # #        And I enter a date of birth "<day>" "<month>" "<year>"
+  # #        And I enter a place of birth "<placeOfBirth>"
+  # #        And I select a preferred title "<preferredTitle>"
+  # #        And I select a preferred first name "<preferredFirstName>"
+  # #        And I select a preferred middle name "<preferredMiddleName>"
+  # #        And I select a preferred last name "<preferredLastName>"
+  # #        And I enter a reason for creation
+  # #        And I click add person
+  # #        Then I am on the create contact for a new tenure page
+  # #        And I click the add email address button
+  # #        And I enter an email address "<email>"
+  # #        And I enter an email description "<emailDescription>"
+  # #        And I click save email address
+  # #        And the email information is captured "<email>" "<emailDescription>"
+  # #        And I click the add phone number button
+  # #        And I enter a phone number "<phoneNumber>"
+  # #        And I select a phone number type "<phoneType>"
+  # #        And I enter a phone number description "<phoneDescription>"
+  # #        And I click save phone number
+  # #        And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
+  # #        And I click done button
+  # #        And the tenure person search is displayed
+  # #
+  # #        Examples:
+  # #        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
+  # #        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
+  # #
+  # #
+  # #    @ignore
+  # #    Scenario Outline: Create person for new tenure validation
+  # #        Given I delete all existing persons from the tenure "<tenure>"
+  # #        When I navigate to a create person for new tenure "<property>" "<tenure>"
+  # #        When I enter any of the following criteria "<searchTerm>"
+  # #        And I click on the search button
+  # #        When I add 5 named tenure holder
+  # #        Then a new tenure error message appears "Max. tenure holders added"
+  # #        And I click create new person
+  # #        And I am on the create new person for a new tenure page
+  # #        And the named tenure holder button is not active
+  # #        And I remove one of the tenure holders
+  # #        And I click the cancel button
+  # #        And I remove one of the tenure holders
+  # #        And I click remove person
+  # #        Then the person is removed
+  # #        When I select person type "Named tenure holder"
+  # #        And I select a title "<title>"
+  # #        And I enter a first name "<firstName>"
+  # #        And I enter a last name "<lastName>"
+  # #        And I enter a date of birth "<day>" "<month>" "<year>"
+  # #        And I enter a reason for creation
+  # #        And I click done button
+  # #
+  # #        Examples:
+  # #        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
+  # #        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
+  # #
+  # #    @regression
+  # #    Scenario Outline: End dates are editable for all tenure types
+  # #      When I edit a Tenure "<tenure>"
+  # #      When I select a tenure type "<tenureType>"
+  # #      Then the tenure end date is editable
+  # #
+  # #      Examples:
+  # #        | tenure                               | tenureType       |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold         |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold (Serv)  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Introductory     |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Leasehold (RTB)  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | License Temp Ac  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Lse 100% Stair   |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Mesne Profit Ac  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Non-Secure       |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Private Sale LH  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Rent To Mortgage |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure           |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Equity    |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Owners    |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Short Life Lse   |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Annex       |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp B&B         |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Decant      |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel      |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel Lse  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Private Lt  |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Traveller   |
+  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Tenant Acc Flat  |
 
 
-#      | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
-#      | Freehold   | 01       | 01         | 2000      | tre        | sar         |
+  # #      | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
+  # #      | Freehold   | 01       | 01         | 2000      | tre        | sar         |
 
-  @SmokeTest
-  Scenario: Create new tenure and cancel
-    Given I seeded the database
-    When I view a property ""
-    When I click on the new tenure button
-    Then I am on the create new tenure page ""
-    Then the new tenure landing page is displayed
-    And I click the cancel button
-    Then the cancel confirmation modal is displayed
-    And I click the modal cancel button
-    Then the new tenure landing page is displayed
-    And I click the cancel button
-    Then the cancel confirmation modal is displayed
-    And I click the confirm button
-    Then the property information is displayed
+  #   @SmokeTest
+  #   Scenario: Create new tenure and cancel
+  #     Given I seeded the database
+  #     When I view a property ""
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page ""
+  #     Then the new tenure landing page is displayed
+  #     And I click the cancel button
+  #     Then the cancel confirmation modal is displayed
+  #     And I click the modal cancel button
+  #     Then the new tenure landing page is displayed
+  #     And I click the cancel button
+  #     Then the cancel confirmation modal is displayed
+  #     And I click the confirm button
+  #     Then the property information is displayed
 
-  @SmokeTest
-  Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
-    When I view a property "<property>"
-    When I click on the new tenure button
-    Then I am on the create new tenure page "<property>"
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I click the next button
-    Then a create tenure error is triggered "Start date must occur after the end date of the previous tenure"
+  #   @SmokeTest
+  #   Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
+  #     When I view a property "<property>"
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page "<property>"
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I click the next button
+  #     Then a create tenure error is triggered "Start date must occur after the end date of the previous tenure"
 
-    Examples:
-      | property                             | tenureType | startDay | startMonth | startYear |
-      | 9db41416-a919-308f-4d7e-9fd25baf0c5b | Freehold   | 01       | 01         | 1900      |
+  #     Examples:
+  #       | property                             | tenureType | startDay | startMonth | startYear |
+  #       | 9db41416-a919-308f-4d7e-9fd25baf0c5b | Freehold   | 01       | 01         | 1900      |
 
-  @SmokeTest
-  Scenario Outline: Create new tenure with start date that occurs after end date
-    Given I seeded the database
-    When I view a property ""
-    When I click on the new tenure button
-    Then I am on the create new tenure page ""
-    Then the new tenure landing page is displayed
-    When I select a tenure type "<tenureType>"
-    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-    And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
-    And I click the next button
-    Then a create tenure error is triggered "End date must occur after start date"
+  #   @SmokeTest
+  #   Scenario Outline: Create new tenure with start date that occurs after end date
+  #     Given I seeded the database
+  #     When I view a property ""
+  #     When I click on the new tenure button
+  #     Then I am on the create new tenure page ""
+  #     Then the new tenure landing page is displayed
+  #     When I select a tenure type "<tenureType>"
+  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #     And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
+  #     And I click the next button
+  #     Then a create tenure error is triggered "End date must occur after start date"
 
-    Examples:
-      | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
-      | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
+  #     Examples:
+  #       | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
+  #       | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
 
   Scenario Outline: Edit existing tenure
     Given I seeded the database
@@ -595,7 +596,7 @@ Feature: Create tenure
 
     Examples:
       | tenureType | day | month | year |
-      | Freehold   |  20 |  05   | 2022 |
+      | Freehold   | 20  | 05    | 2022 |
 
   Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
     When I view a tenure "<tenure>"
@@ -613,33 +614,33 @@ Feature: Create tenure
       | tenure                               |
       | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
 
-#  @ignore
-#  Scenario Outline: Create person for new tenure validation
-#    Given I create a new "" tenure
-#    When I navigate to a create person for new tenure "<property>" "<tenure>"
-#    When I enter any of the following criteria "<searchTerm>"
-#    And I click on the search button
-#    When I add 5 named tenure holder
-#    Then a new tenure error message appears "Max. tenure holders added"
-#    And I click create new person
-#    And I am on the create new person for a new tenure page
-#    And the named tenure holder button is not active
-#    And I remove one of the tenure holders
-#    And I click the cancel button
-#    And I remove one of the tenure holders
-#    And I click remove person
-#    Then the person is removed
-#    When I select person type "Named tenure holder"
-#    And I select a title "<title>"
-#    And I enter a first name "<firstName>"
-#    And I enter a last name "<lastName>"
-#    And I enter a date of birth "<day>" "<month>" "<year>"
-#    And I enter a reason for creation
-#    And I click done button
-#
-#    Examples:
-#      | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
-#      | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
+  #  @ignore
+  #  Scenario Outline: Create person for new tenure validation
+  #    Given I create a new "" tenure
+  #    When I navigate to a create person for new tenure "<property>" "<tenure>"
+  #    When I enter any of the following criteria "<searchTerm>"
+  #    And I click on the search button
+  #    When I add 5 named tenure holder
+  #    Then a new tenure error message appears "Max. tenure holders added"
+  #    And I click create new person
+  #    And I am on the create new person for a new tenure page
+  #    And the named tenure holder button is not active
+  #    And I remove one of the tenure holders
+  #    And I click the cancel button
+  #    And I remove one of the tenure holders
+  #    And I click remove person
+  #    Then the person is removed
+  #    When I select person type "Named tenure holder"
+  #    And I select a title "<title>"
+  #    And I enter a first name "<firstName>"
+  #    And I enter a last name "<lastName>"
+  #    And I enter a date of birth "<day>" "<month>" "<year>"
+  #    And I enter a reason for creation
+  #    And I click done button
+  #
+  #    Examples:
+  #      | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
+  #      | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
 
   @regression
   Scenario Outline: End dates are editable for all tenure types

--- a/cypress/e2e/createTenure.feature
+++ b/cypress/e2e/createTenure.feature
@@ -19,600 +19,540 @@ Feature: Create tenure
   #      | tableName          |
   #      | TenureInformation  |
   #
-  # TEMPORARILY COMMENTED OUT FROM LINE 23 TO LINE 543 (SOME TESTS HAD ALREADY BEEN COMMENTED OUT, SO THEY'LL HAVE TO "##" NOW)
-  #   @ignore
-  #   @SmokeTest
-  #   Scenario Outline: Create new tenure
-  #     When I view a property "<property>"
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page "<property>"
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-
-  #     Examples:
-  #         | property                             | tenureType | startDay | startMonth | startYear |
-  #         | 05f2a78d-bc9d-255d-0c1c-98e7add1ca95 | Non-Secure   | 01       | 01         | 2000      |
-  #      #   | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      |
-
-  # @ignore
-  #   @SmokeTest
-  #   Scenario Outline: Create new tenure search and select existing resident to add to the new tenure
-  #   #Then I can delete a created record from DynamoDb "<tableName>"
-  #     When I view a property "<property>"
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page "<property>"
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-  #     When I enter any of the following criteria "<searchTerm>"
-  #     And I click on the search button
-  #     Then the search results are displayed by best match "<searchTerm>"
-  #     When I add 1 named tenure holder
-  #     Then the person is added to the tenure
-  #   #Then I can delete a created record from DynamoDb "<tableName>"
-  #       ###   The below 2 steps are throwing an error in UI when adding the same person as householder member'The person is already added'
-  # #    When I add 1 household member
-  # #    Then the person is added to the tenure
-  # #    And I click done button
-  # #    Then the message New tenure completed is displayed
-  # #    Then the tenure information is displayed
-
-  #     Examples:
-  #         | property                             | tenureType | startDay | startMonth | startYear | searchTerm |tableName          |
-  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 21       | 05         | 2022      | tre        |TenureInformation  |
-
-  #   @ignore
-  #     @SmokeTest
-  #   Scenario Outline: Create new tenure search and select resident
-  #     When I view a property "<property>"
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page "<property>"
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-  #     When I enter any of the following criteria "<searchTerm>"
-  #     And I click on the search button
-  #     Then the search results are displayed by best match "<searchTerm>"
-  #     When I add 1 named tenure holder
-  #     Then the person is added to the tenure
-  #     When I add 1 household member
-  #     Then the person is added to the tenure
-  #     And I click done button
-  #     Then the message New tenure completed is displayed
-  #     Then the tenure information is displayed
-
-  #     Examples:
-  #       | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
-  #       | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
-
-  #   @ignore
-  #   Scenario Outline: Create new tenure and filter search
-  #     When I view a property "<property>"
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page "<property>"
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-  #     When I enter any of the following criteria "<searchTerm>"
-  #     And I click on the search button
-  #     Then the search results are displayed by best match "<searchTerm>"
-  #     Then the default sort option is correct
-  #     When I select to sort by "<filter>"
-  #     When I set the number of results to <results>
-  #     Then the correct number of <results> are displayed
-
-  #     Examples:
-  #         | property                             | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
-  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
-  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
-  #         | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
-
-  #   @SmokeTest
-  #   Scenario Outline: Create new tenure
-  #     Given I seeded the database
-  #     When I view a property ""
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page ""
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-
-  #     Examples:
-  #       | tenureType | startDay | startMonth | startYear |
-  #       | Non-Secure   | 01       | 01         | 2000      |
-
-  #   @SmokeTest
-  #   Scenario Outline: Create new tenure search and select resident
-  #     Given I seeded the database
-  #     When I view a property ""
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page ""
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-  #     When I enter any of the following criteria "<searchTerm>"
-  #     And I click on the search button
-  #     Then the search results are displayed by best match "<searchTerm>"
-  #     When I add 1 named tenure holder
-  #     Then the person is added to the tenure
-  #     When I enter any of the following criteria "<searchTerm2>"
-  #     And I click on the search button
-  #     When I add 1 household member
-  #     Then the person is added to the tenure
-  #     And I click done button
-  #     Then the message New tenure completed is displayed
-  #     Then the tenure information is displayed
-
-  #     Examples:
-  #       | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
-  #       | Freehold   | 01       | 01         | 2000      | tre        | sar         |
-
-  #   Scenario Outline: Create new tenure and filter search
-  #     Given I seeded the database
-  #     When I view a property ""
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page ""
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     And the tenure person search is displayed
-  #     When I enter any of the following criteria "<searchTerm>"
-  #     And I click on the search button
-  #     Then the search results are displayed by best match "<searchTerm>"
-  #     Then the default sort option is correct
-  #     When I select to sort by "<filter>"
-  #     When I set the number of results to <results>
-  #     Then the correct number of <results> are displayed
-
-  #     Examples:
-  #       | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
-  #       | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
-  #       | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
-  #       | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
-
-  # #  @ignore
-  # #  Scenario Outline: Create new tenure and add new person
-  # #    Given I create a new property
-  # #    When I view a property ""
-  # #    When I click on the new tenure button
-  # #    Then I am on the create new tenure page ""
-  # #    Then the new tenure landing page is displayed
-  # #    When I select a tenure type "<tenureType>"
-  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  # #    And I click the next button
-  # #    And the tenure person search is displayed
-  # #    And the create new person button is not enabled
-  # #    When I enter any of the following criteria "<searchTerm>"
-  # #    And I click on the search button
-  # #    And I click create new person
-  # #    And I am on the create new person for a new tenure page
-  # #    When I select person type "<personType>"
-  # #    And I select a title "<title>"
-  # #    And I enter a first name "<firstName>"
-  # #    And I enter a middle name "<middleName>"
-  # #    And I enter a last name "<lastName>"
-  # #    And I enter a date of birth "<day>" "<month>" "<year>"
-  # #    And I enter a place of birth "<placeOfBirth>"
-  # #    And I select a preferred title "<preferredTitle>"
-  # #    And I select a preferred first name "<preferredFirstName>"
-  # #    And I select a preferred middle name "<preferredMiddleName>"
-  # #    And I select a preferred last name "<preferredLastName>"
-  # #    And I enter a reason for creation
-  # #    And I click add person
-  # #    Then the person is added to the tenure
-  # #    And I am on the create contact for a new tenure page
-  # #    Then I click the add email address button
-  # #    And I enter an email address "<email>"
-  # #    And I enter an email description "<emailDescription>"
-  # #    And I click save email address
-  # #    And the email information is captured "<email>" "<emailDescription>"
-  # #    And I click the add phone number button
-  # #    And I enter a phone number "<phoneNumber>"
-  # #    And I select a phone number type "<phoneType>"
-  # #    And I enter a phone number description "<phoneDescription>"
-  # #    And I click save phone number
-  # #    And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
-  # #    And I click the next button
-  # #    And I click the save equality information button
-  # #    And the person is added to the list of tenures "<title>" "<firstName>" "<middleName>" "<lastName>" "<day>" "<month>" "<year>"
-  # #    And the tenure person search is displayed
-  # #
-  # #        Examples:
-  # #        | property                             | tenureType | startDay | startMonth | startYear | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
-  # #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
-  # #
-  # #  @ignore
-  # #  Scenario Outline: Create new tenure validation
-  # #    Given I create a new property
-  # #    When I view a property ""
-  # #    When I click on the new tenure button
-  # #    Then I am on the create new tenure page ""
-  # #    Then the new tenure landing page is displayed
-  # #    When I select a tenure type "<tenureType>"
-  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  # #    And I click the next button
-  # #    And the tenure person search is displayed
-  # #    When I enter any of the following criteria "<searchTerm>"
-  # #    And I click on the search button
-  # #    Then the search results are displayed by best match "<searchTerm>"
-  # #    When I add 1 named tenure holder
-  # #    Then the person is added to the tenure
-  # #    When I add 1 named tenure holder
-  # #    Then a new tenure error message appears "The person is already added"
-  # #    When I enter any of the following criteria "<searchTerm2>"
-  # #    And I click on the search button
-  # #    When I add 1 household member
-  # #    Then the person is added to the tenure
-  # #    When I add 1 household member
-  # #    Then a new tenure error message appears "The person is already added"
-  # #    When I add 5 named tenure holder
-  # #    Then a new tenure error message appears "Max. tenure holders added"
-  # #
-  # #    Examples:
-  # #        | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
-  # #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
-  # #
-  # #  @ignore
-  # #  @SmokeTest
-  # #  Scenario Outline: Create new tenure and cancel
-  # #    When I view a property "<property>"
-  # #    When I click on the new tenure button
-  # #    Then I am on the create new tenure page "<property>"
-  # #    Then the new tenure landing page is displayed
-  # #    And I click the cancel button
-  # #    Then the cancel confirmation modal is displayed
-  # #    And I click the modal cancel button
-  # #    Then the new tenure landing page is displayed
-  # #    And I click the cancel button
-  # #    Then the cancel confirmation modal is displayed
-  # #    And I click the confirm button
-  # #    Then the property information is displayed
-  # #
-  # #    Examples:
-  # #        | property                             |
-  # #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 |
-  # #
-  # #  @SmokeTest
-  # #  Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
-  # #    When I view a property "<property>"
-  # #    When I click on the new tenure button
-  # #    Then I am on the create new tenure page "<property>"
-  # #    Then the new tenure landing page is displayed
-  # #    When I select a tenure type "<tenureType>"
-  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  # #    And I click the next button
-  # #    Then a create tenure error is triggered
-  # #
-  # #    Examples:
-  # #        | property                             | tenureType | startDay | startMonth | startYear |
-  # #        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Freehold   | 01       | 01         | 1900      |
-  # #
-  # #  @SmokeTest
-  # #  Scenario Outline: Create new tenure that with start date that occurs after end date
-  # #    When I view a property "<property>"
-  # #    When I click on the new tenure button
-  # #    Then I am on the create new tenure page "<property>"
-  # #    Then the new tenure landing page is displayed
-  # #    When I select a tenure type "<tenureType>"
-  # #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  # #    And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
-  # #    And I click the next button
-  # #    Then a create tenure error is triggered
-  # #
-  # #    Examples:
-  # #        | property                             | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
-  # #        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
-  # #
-  # #  @ignore
-  # #  Scenario Outline: Edit existing tenure
-  # #        When I view a Tenure "<tenure>"
-  # #        Then the tenure information is displayed
-  # #        And I click edit tenure
-  # #        Then the edit tenure information is displayed
-  # #        When I select a tenure type "<tenureType>"
-  # #        And I click done button
-  # #        Then the edit tenure information is displayed "<tenure>"
-  # #
-  # #        Examples:
-  # #        | tenure                               | tenureType |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
-  # #        # | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure     |
-  # #
-  # #    Scenario Outline: Edit existing tenure and cancel
-  # #        When I view a Tenure "<tenure>"
-  # #        Then the tenure information is displayed
-  # #        And I click edit tenure
-  # #        Then the edit tenure information is displayed
-  # #        When I select a tenure type "<tenureType>"
-  # #        And I click the cancel button
-  # #        Then the cancel modal is displayed
-  # #        When I click cancel on the modal
-  # #        Then the edit tenure information is displayed
-  # #        And I click the cancel button
-  # #        Then the cancel modal is displayed
-  # #        And I click yes on the modal
-  # #        Then the tenure information is displayed
-  # #
-  # #        Examples:
-  # #        | tenure                               | tenureType |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
-
-  # #
-  # #  Scenario Outline: Display Confirmation Alert pop up when ending a Tenure
-  # #    When I view a Tenure "<tenure>"
-  # #    Then the tenure information is displayed
-  # #    And I click edit tenure
-  # #    Then the edit tenure information is displayed
-  # #    When I select a tenure type "<tenureType>"
-  # #    And I enter a tenure end date as "<day>" "<month>" "<year>"
-  # #    And I click the next button
-  # #    Then the warning modal is displayed
-  # #    And the information text is displayed
-  # #    When I click cancel on the modal
-  # #    Then the edit tenure information is displayed
-  # #    # When the below steps are executed the test data will be unvailable for the next run as edit tenure button will not be displayed
-  # #    #When I click yes on the modal
-  # #    #Then the tenure information is displayed with the page heading Tenure updated
-  # #
-  # #    Examples:
-  # #      | tenure                               | tenureType | day | month | year |
-  # #      | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |  20 |  05   | 2022 |
-  # #
-  # #    Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
-  # #        When I view a Tenure "<tenure>"
-  # #        Then the tenure information is displayed
-  # #        And the edit tenure button is not displayed
-  # #        Examples:
-  # #        | tenure                               |
-  # #        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
-  # #
-  # #    Scenario Outline: Cannot edit tenure for inactive or past tenures
-  # #        When I edit a Tenure "<tenure>"
-  # #        Then the tenure cannot be edited warning message is displayed
-  # #
-  # #        Examples:
-  # #        | tenure                               |
-  # #        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
-  # #
-  # #    @ignore
-  # #    Scenario Outline: Create person by navigating to new tenure
-  # #        Given I delete all existing persons from the tenure "<tenure>"
-  # #        When I navigate to a create person for new tenure "<property>" "<tenure>"
-  # #        And the tenure person search is displayed
-  # #        And the create new person button is not enabled
-  # #        When I enter any of the following criteria "<searchTerm>"
-  # #        And I click on the search button
-  # #        And I click create new person
-  # #        And I am on the create new person for a new tenure page
-  # #        When I select person type "<personType>"
-  # #        And I select a title "<title>"
-  # #        And I enter a first name "<firstName>"
-  # #        And I enter a middle name "<middleName>"
-  # #        And I enter a last name "<lastName>"
-  # #        And I enter a date of birth "<day>" "<month>" "<year>"
-  # #        And I enter a place of birth "<placeOfBirth>"
-  # #        And I select a preferred title "<preferredTitle>"
-  # #        And I select a preferred first name "<preferredFirstName>"
-  # #        And I select a preferred middle name "<preferredMiddleName>"
-  # #        And I select a preferred last name "<preferredLastName>"
-  # #        And I enter a reason for creation
-  # #        And I click add person
-  # #        Then I am on the create contact for a new tenure page
-  # #        And I click the add email address button
-  # #        And I enter an email address "<email>"
-  # #        And I enter an email description "<emailDescription>"
-  # #        And I click save email address
-  # #        And the email information is captured "<email>" "<emailDescription>"
-  # #        And I click the add phone number button
-  # #        And I enter a phone number "<phoneNumber>"
-  # #        And I select a phone number type "<phoneType>"
-  # #        And I enter a phone number description "<phoneDescription>"
-  # #        And I click save phone number
-  # #        And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
-  # #        And I click done button
-  # #        And the tenure person search is displayed
-  # #
-  # #        Examples:
-  # #        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
-  # #        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
-  # #
-  # #
-  # #    @ignore
-  # #    Scenario Outline: Create person for new tenure validation
-  # #        Given I delete all existing persons from the tenure "<tenure>"
-  # #        When I navigate to a create person for new tenure "<property>" "<tenure>"
-  # #        When I enter any of the following criteria "<searchTerm>"
-  # #        And I click on the search button
-  # #        When I add 5 named tenure holder
-  # #        Then a new tenure error message appears "Max. tenure holders added"
-  # #        And I click create new person
-  # #        And I am on the create new person for a new tenure page
-  # #        And the named tenure holder button is not active
-  # #        And I remove one of the tenure holders
-  # #        And I click the cancel button
-  # #        And I remove one of the tenure holders
-  # #        And I click remove person
-  # #        Then the person is removed
-  # #        When I select person type "Named tenure holder"
-  # #        And I select a title "<title>"
-  # #        And I enter a first name "<firstName>"
-  # #        And I enter a last name "<lastName>"
-  # #        And I enter a date of birth "<day>" "<month>" "<year>"
-  # #        And I enter a reason for creation
-  # #        And I click done button
-  # #
-  # #        Examples:
-  # #        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
-  # #        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
-  # #
-  # #    @regression
-  # #    Scenario Outline: End dates are editable for all tenure types
-  # #      When I edit a Tenure "<tenure>"
-  # #      When I select a tenure type "<tenureType>"
-  # #      Then the tenure end date is editable
-  # #
-  # #      Examples:
-  # #        | tenure                               | tenureType       |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold         |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold (Serv)  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Introductory     |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Leasehold (RTB)  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | License Temp Ac  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Lse 100% Stair   |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Mesne Profit Ac  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Non-Secure       |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Private Sale LH  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Rent To Mortgage |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure           |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Equity    |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Owners    |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Short Life Lse   |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Annex       |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp B&B         |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Decant      |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel      |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel Lse  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Private Lt  |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Traveller   |
-  # #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Tenant Acc Flat  |
-
-
-  # #      | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
-  # #      | Freehold   | 01       | 01         | 2000      | tre        | sar         |
-
-  #   @SmokeTest
-  #   Scenario: Create new tenure and cancel
-  #     Given I seeded the database
-  #     When I view a property ""
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page ""
-  #     Then the new tenure landing page is displayed
-  #     And I click the cancel button
-  #     Then the cancel confirmation modal is displayed
-  #     And I click the modal cancel button
-  #     Then the new tenure landing page is displayed
-  #     And I click the cancel button
-  #     Then the cancel confirmation modal is displayed
-  #     And I click the confirm button
-  #     Then the property information is displayed
-
-  #   @SmokeTest
-  #   Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
-  #     When I view a property "<property>"
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page "<property>"
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I click the next button
-  #     Then a create tenure error is triggered "Start date must occur after the end date of the previous tenure"
-
-  #     Examples:
-  #       | property                             | tenureType | startDay | startMonth | startYear |
-  #       | 9db41416-a919-308f-4d7e-9fd25baf0c5b | Freehold   | 01       | 01         | 1900      |
-
-  #   @SmokeTest
-  #   Scenario Outline: Create new tenure with start date that occurs after end date
-  #     Given I seeded the database
-  #     When I view a property ""
-  #     When I click on the new tenure button
-  #     Then I am on the create new tenure page ""
-  #     Then the new tenure landing page is displayed
-  #     When I select a tenure type "<tenureType>"
-  #     And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
-  #     And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
-  #     And I click the next button
-  #     Then a create tenure error is triggered "End date must occur after start date"
-
-  #     Examples:
-  #       | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
-  #       | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
-
-  Scenario Outline: Edit existing tenure
-    Given I seeded the database
-    When I view a tenure ""
-    Then the tenure information is displayed
-    And I click edit tenure
-    Then the edit tenure information is displayed
+  @ignore
+  @SmokeTest
+  Scenario Outline: Create new tenure
+    Given I seeded the database with an asset "<property>" with no attached tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
     When I select a tenure type "<tenureType>"
+    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
     And I click the next button
-    Then the edit tenure information is displayed
+    And the tenure person search is displayed
 
     Examples:
-      | tenureType |
-      | Freehold   |
+      | property                             | tenureType | startDay | startMonth | startYear |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Non-Secure | 01       | 01         | 2000      |
+  #   | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      |
 
-  Scenario Outline: Edit existing tenure and cancel
-    Given I seeded the database
-    When I view a tenure ""
-    Then the tenure information is displayed
-    And I click edit tenure
-    Then the edit tenure information is displayed
+  @ignore
+  @SmokeTest
+  Scenario Outline: Create new tenure search and select existing resident to add to the new tenure
+    #Then I can delete a created record from DynamoDb "<tableName>"
+    Given I seeded the database with an asset "<property>" with no attached tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
     When I select a tenure type "<tenureType>"
+    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+    And I click the next button
+    And the tenure person search is displayed
+    When I enter any of the following criteria "<searchTerm>"
+    And I click on the search button
+    Then the search results are displayed by best match "<searchTerm>"
+    When I add 1 named tenure holder
+    Then the person is added to the tenure
+    #Then I can delete a created record from DynamoDb "<tableName>"
+    ###   The below 2 steps are throwing an error in UI when adding the same person as householder member'The person is already added'
+    #    When I add 1 household member
+    #    Then the person is added to the tenure
+    #    And I click done button
+    #    Then the message New tenure completed is displayed
+    #    Then the tenure information is displayed
+
+    Examples:
+      | property                             | tenureType | startDay | startMonth | startYear | searchTerm | tableName         |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Freehold   | 21       | 05         | 2022      | tre        | TenureInformation |
+
+  @ignore
+  @SmokeTest
+  Scenario Outline: Create new tenure search and select resident
+    Given I seeded the database with an asset "<property>" with no attached tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
+    When I select a tenure type "<tenureType>"
+    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+    And I click the next button
+    And the tenure person search is displayed
+    When I enter any of the following criteria "<searchTerm>"
+    And I click on the search button
+    Then the search results are displayed by best match "<searchTerm>"
+    When I add 1 named tenure holder
+    Then the person is added to the tenure
+    When I add 2 household member
+    Then the person is added to the tenure
+    And I click done button
+    Then the message New tenure completed is displayed
+    Then the tenure information is displayed
+
+    Examples:
+      | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Freehold   | 01       | 01         | 2000      | tre        |
+
+  @ignore
+  Scenario Outline: Create new tenure and filter search
+    Given I seeded the database with an asset "<property>" with no attached tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
+    When I select a tenure type "<tenureType>"
+    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+    And I click the next button
+    And the tenure person search is displayed
+    When I enter any of the following criteria "<searchTerm>"
+    And I click on the search button
+    Then the search results are displayed by best match "<searchTerm>"
+    Then the default sort option is correct
+    When I select to sort by "<filter>"
+    When I set the number of results to <results>
+    Then the correct number of <results> are displayed
+
+    Examples:
+      | property                             | tenureType | startDay | startMonth | startYear | searchTerm | filter        | results |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Freehold   | 01       | 01         | 2000      | tre        | Last name A-Z | 40      |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Freehold   | 01       | 01         | 2000      | tre        | Last name Z-A | 20      |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Freehold   | 01       | 01         | 2000      | tre        | Best match    | 12      |
+
+  #  @ignore
+  #  Scenario Outline: Create new tenure and add new person
+  #    Given I create a new property
+  #    When I view a property "<property>"
+  #    When I click on the new tenure button
+  #    Then I am on the create new tenure page ""
+  #    Then the new tenure landing page is displayed
+  #    When I select a tenure type "<tenureType>"
+  #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #    And I click the next button
+  #    And the tenure person search is displayed
+  #    And the create new person button is not enabled
+  #    When I enter any of the following criteria "<searchTerm>"
+  #    And I click on the search button
+  #    And I click create new person
+  #    And I am on the create new person for a new tenure page
+  #    When I select person type "<personType>"
+  #    And I select a title "<title>"
+  #    And I enter a first name "<firstName>"
+  #    And I enter a middle name "<middleName>"
+  #    And I enter a last name "<lastName>"
+  #    And I enter a date of birth "<day>" "<month>" "<year>"
+  #    And I enter a place of birth "<placeOfBirth>"
+  #    And I select a preferred title "<preferredTitle>"
+  #    And I select a preferred first name "<preferredFirstName>"
+  #    And I select a preferred middle name "<preferredMiddleName>"
+  #    And I select a preferred last name "<preferredLastName>"
+  #    And I enter a reason for creation
+  #    And I click add person
+  #    Then the person is added to the tenure
+  #    And I am on the create contact for a new tenure page
+  #    Then I click the add email address button
+  #    And I enter an email address "<email>"
+  #    And I enter an email description "<emailDescription>"
+  #    And I click save email address
+  #    And the email information is captured "<email>" "<emailDescription>"
+  #    And I click the add phone number button
+  #    And I enter a phone number "<phoneNumber>"
+  #    And I select a phone number type "<phoneType>"
+  #    And I enter a phone number description "<phoneDescription>"
+  #    And I click save phone number
+  #    And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
+  #    And I click the next button
+  #    And I click the save equality information button
+  #    And the person is added to the list of tenures "<title>" "<firstName>" "<middleName>" "<lastName>" "<day>" "<month>" "<year>"
+  #    And the tenure person search is displayed
+  #
+  #        Examples:
+  #        | property                             | tenureType | startDay | startMonth | startYear | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
+  #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
+  #
+  #  @ignore
+  #  Scenario Outline: Create new tenure validation
+  #    Given I create a new property
+  #    When I view a property ""
+  #    When I click on the new tenure button
+  #    Then I am on the create new tenure page ""
+  #    Then the new tenure landing page is displayed
+  #    When I select a tenure type "<tenureType>"
+  #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #    And I click the next button
+  #    And the tenure person search is displayed
+  #    When I enter any of the following criteria "<searchTerm>"
+  #    And I click on the search button
+  #    Then the search results are displayed by best match "<searchTerm>"
+  #    When I add 1 named tenure holder
+  #    Then the person is added to the tenure
+  #    When I add 1 named tenure holder
+  #    Then a new tenure error message appears "The person is already added"
+  #    When I enter any of the following criteria "<searchTerm2>"
+  #    And I click on the search button
+  #    When I add 1 household member
+  #    Then the person is added to the tenure
+  #    When I add 1 household member
+  #    Then a new tenure error message appears "The person is already added"
+  #    When I add 5 named tenure holder
+  #    Then a new tenure error message appears "Max. tenure holders added"
+  #
+  #    Examples:
+  #        | property                             | tenureType | startDay | startMonth | startYear | searchTerm |
+  #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 | Freehold   | 01       | 01         | 2000      | tre        |
+  #
+  #  @ignore
+  #  @SmokeTest
+  #  Scenario Outline: Create new tenure and cancel
+  #    When I view a property "<property>"
+  #    When I click on the new tenure button
+  #    Then I am on the create new tenure page "<property>"
+  #    Then the new tenure landing page is displayed
+  #    And I click the cancel button
+  #    Then the cancel confirmation modal is displayed
+  #    And I click the modal cancel button
+  #    Then the new tenure landing page is displayed
+  #    And I click the cancel button
+  #    Then the cancel confirmation modal is displayed
+  #    And I click the confirm button
+  #    Then the property information is displayed
+  #
+  #    Examples:
+  #        | property                             |
+  #        | aff61bd4-841b-b4dc-af23-dfbdb8cc8434 |
+  #
+  #  @SmokeTest
+  #  Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
+  #    When I view a property "<property>"
+  #    When I click on the new tenure button
+  #    Then I am on the create new tenure page "<property>"
+  #    Then the new tenure landing page is displayed
+  #    When I select a tenure type "<tenureType>"
+  #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #    And I click the next button
+  #    Then a create tenure error is triggered
+  #
+  #    Examples:
+  #        | property                             | tenureType | startDay | startMonth | startYear |
+  #        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Freehold   | 01       | 01         | 1900      |
+  #
+  #  @SmokeTest
+  #  Scenario Outline: Create new tenure that with start date that occurs after end date
+  #    When I view a property "<property>"
+  #    When I click on the new tenure button
+  #    Then I am on the create new tenure page "<property>"
+  #    Then the new tenure landing page is displayed
+  #    When I select a tenure type "<tenureType>"
+  #    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+  #    And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
+  #    And I click the next button
+  #    Then a create tenure error is triggered
+  #
+  #    Examples:
+  #        | property                             | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
+  #        | 986a2a9e-9eb4-0966-120a-238689e3e265 | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
+  #
+  #  @ignore
+  #  Scenario Outline: Edit existing tenure
+  #        When I view a Tenure "<tenure>"
+  #        Then the tenure information is displayed
+  #        And I click edit tenure
+  #        Then the edit tenure information is displayed
+  #        When I select a tenure type "<tenureType>"
+  #        And I click done button
+  #        Then the edit tenure information is displayed "<tenure>"
+  #
+  #        Examples:
+  #        | tenure                               | tenureType |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
+  #        # | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure     |
+  #
+  #    Scenario Outline: Edit existing tenure and cancel
+  #        When I view a Tenure "<tenure>"
+  #        Then the tenure information is displayed
+  #        And I click edit tenure
+  #        Then the edit tenure information is displayed
+  #        When I select a tenure type "<tenureType>"
+  #        And I click the cancel button
+  #        Then the cancel modal is displayed
+  #        When I click cancel on the modal
+  #        Then the edit tenure information is displayed
+  #        And I click the cancel button
+  #        Then the cancel modal is displayed
+  #        And I click yes on the modal
+  #        Then the tenure information is displayed
+  #
+  #        Examples:
+  #        | tenure                               | tenureType |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |
+
+  #
+  #  Scenario Outline: Display Confirmation Alert pop up when ending a Tenure
+  #    When I view a Tenure "<tenure>"
+  #    Then the tenure information is displayed
+  #    And I click edit tenure
+  #    Then the edit tenure information is displayed
+  #    When I select a tenure type "<tenureType>"
+  #    And I enter a tenure end date as "<day>" "<month>" "<year>"
+  #    And I click the next button
+  #    Then the warning modal is displayed
+  #    And the information text is displayed
+  #    When I click cancel on the modal
+  #    Then the edit tenure information is displayed
+  #    # When the below steps are executed the test data will be unvailable for the next run as edit tenure button will not be displayed
+  #    #When I click yes on the modal
+  #    #Then the tenure information is displayed with the page heading Tenure updated
+  #
+  #    Examples:
+  #      | tenure                               | tenureType | day | month | year |
+  #      | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold   |  20 |  05   | 2022 |
+  #
+  #    Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
+  #        When I view a Tenure "<tenure>"
+  #        Then the tenure information is displayed
+  #        And the edit tenure button is not displayed
+  #        Examples:
+  #        | tenure                               |
+  #        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+  #
+  #    Scenario Outline: Cannot edit tenure for inactive or past tenures
+  #        When I edit a Tenure "<tenure>"
+  #        Then the tenure cannot be edited warning message is displayed
+  #
+  #        Examples:
+  #        | tenure                               |
+  #        | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+  #
+  #    @ignore
+  #    Scenario Outline: Create person by navigating to new tenure
+  #        Given I delete all existing persons from the tenure "<tenure>"
+  #        When I navigate to a create person for new tenure "<property>" "<tenure>"
+  #        And the tenure person search is displayed
+  #        And the create new person button is not enabled
+  #        When I enter any of the following criteria "<searchTerm>"
+  #        And I click on the search button
+  #        And I click create new person
+  #        And I am on the create new person for a new tenure page
+  #        When I select person type "<personType>"
+  #        And I select a title "<title>"
+  #        And I enter a first name "<firstName>"
+  #        And I enter a middle name "<middleName>"
+  #        And I enter a last name "<lastName>"
+  #        And I enter a date of birth "<day>" "<month>" "<year>"
+  #        And I enter a place of birth "<placeOfBirth>"
+  #        And I select a preferred title "<preferredTitle>"
+  #        And I select a preferred first name "<preferredFirstName>"
+  #        And I select a preferred middle name "<preferredMiddleName>"
+  #        And I select a preferred last name "<preferredLastName>"
+  #        And I enter a reason for creation
+  #        And I click add person
+  #        Then I am on the create contact for a new tenure page
+  #        And I click the add email address button
+  #        And I enter an email address "<email>"
+  #        And I enter an email description "<emailDescription>"
+  #        And I click save email address
+  #        And the email information is captured "<email>" "<emailDescription>"
+  #        And I click the add phone number button
+  #        And I enter a phone number "<phoneNumber>"
+  #        And I select a phone number type "<phoneType>"
+  #        And I enter a phone number description "<phoneDescription>"
+  #        And I click save phone number
+  #        And the phone information is captured "<phoneNumber>" "<phoneType>" "<phoneDescription>"
+  #        And I click done button
+  #        And the tenure person search is displayed
+  #
+  #        Examples:
+  #        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year | placeOfBirth | preferredTitle | preferredFirstName | preferredMiddleName | preferredLastName | email                          | emailDescription              | phoneNumber | phoneType | phoneDescription              |
+  #        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | tre        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 | Hospital     | Mrs            | Alan               | Coach Feratu        | Jefferson         | addPersonToNewTenure@email.com | Add person to new tenure test | 01189998    | Other     | Add person to new tenure test |
+  #
+  #
+  #    @ignore
+  #    Scenario Outline: Create person for new tenure validation
+  #        Given I delete all existing persons from the tenure "<tenure>"
+  #        When I navigate to a create person for new tenure "<property>" "<tenure>"
+  #        When I enter any of the following criteria "<searchTerm>"
+  #        And I click on the search button
+  #        When I add 5 named tenure holder
+  #        Then a new tenure error message appears "Max. tenure holders added"
+  #        And I click create new person
+  #        And I am on the create new person for a new tenure page
+  #        And the named tenure holder button is not active
+  #        And I remove one of the tenure holders
+  #        And I click the cancel button
+  #        And I remove one of the tenure holders
+  #        And I click remove person
+  #        Then the person is removed
+  #        When I select person type "Named tenure holder"
+  #        And I select a title "<title>"
+  #        And I enter a first name "<firstName>"
+  #        And I enter a last name "<lastName>"
+  #        And I enter a date of birth "<day>" "<month>" "<year>"
+  #        And I enter a reason for creation
+  #        And I click done button
+  #
+  #        Examples:
+  #        | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
+  #        | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
+  #
+  #    @regression
+  #    Scenario Outline: End dates are editable for all tenure types
+  #      When I edit a Tenure "<tenure>"
+  #      When I select a tenure type "<tenureType>"
+  #      Then the tenure end date is editable
+  #
+  #      Examples:
+  #        | tenure                               | tenureType       |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold         |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Freehold (Serv)  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Introductory     |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Leasehold (RTB)  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | License Temp Ac  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Lse 100% Stair   |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Mesne Profit Ac  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Non-Secure       |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Private Sale LH  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Rent To Mortgage |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Secure           |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Equity    |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Shared Owners    |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Short Life Lse   |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Annex       |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp B&B         |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Decant      |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel      |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Hostel Lse  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Private Lt  |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Temp Traveller   |
+  #        | aaaf05fb-6a4d-f6ef-592f-4beccbe62ccb | Tenant Acc Flat  |
+
+
+  #      | tenureType | startDay | startMonth | startYear | searchTerm | searchTerm2 |
+  #      | Freehold   | 01       | 01         | 2000      | tre        | sar         |
+
+  @SmokeTest
+  Scenario: Create new tenure and cancel
+    Given I seeded the database with an asset "<property>" with no attached tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
     And I click the cancel button
-    Then the cancel modal is displayed
-    When I click the modal cancel button
-    Then the edit tenure information is displayed
+    Then the cancel confirmation modal is displayed
+    And I click the modal cancel button
+    Then the new tenure landing page is displayed
     And I click the cancel button
-    Then the cancel modal is displayed
+    Then the cancel confirmation modal is displayed
     And I click the confirm button
-    Then the tenure information is displayed
+    Then the property information is displayed
 
     Examples:
-      | tenureType |
-      | Freehold   |
+      | property                             |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 |
 
-  Scenario Outline: Display Confirmation Alert pop up when ending a Tenure
-    Given I seeded the database
-    When I view a tenure ""
-    Then the tenure information is displayed
-    And I click edit tenure
-    Then the edit tenure information is displayed
+  @SmokeTest
+  Scenario Outline: Create new tenure that occurs before the end date of a previous tenure
+    Given I seeded the database with an asset "<property>" with a previous tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
     When I select a tenure type "<tenureType>"
-    And I enter a tenure end date as "<day>" "<month>" "<year>"
+    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
     And I click the next button
-    Then the warning modal is displayed
-    And the information text is displayed
-    When I click the modal cancel button
-    Then the edit tenure information is displayed
-    When I click the next button
-    Then the warning modal is displayed
-    When I click yes on the modal
-    Then the tenure information is displayed with the page heading Tenure updated
+    Then a create tenure error is triggered "Start date must occur after the end date of the previous tenure"
 
     Examples:
-      | tenureType | day | month | year |
-      | Freehold   | 20  | 05    | 2022 |
+      | property                             | tenureType | startDay | startMonth | startYear |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Freehold   | 20       | 05         | 2022      |
 
-  Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
-    When I view a tenure "<tenure>"
-    Then the tenure information is displayed
-    And the edit tenure button is not displayed
+  @SmokeTest
+  Scenario Outline: Create new tenure with start date that occurs after end date
+    Given I seeded the database with an asset "<property>" with no attached tenure
+    When I view a property "<property>"
+    When I click on the new tenure button
+    Then I am on the create new tenure page "<property>"
+    Then the new tenure landing page is displayed
+    When I select a tenure type "<tenureType>"
+    And I enter a tenure start date "<startDay>" "<startMonth>" "<startYear>"
+    And I enter a tenure end date "<endDay>" "<endMonth>" "<endYear>"
+    And I click the next button
+    Then a create tenure error is triggered "End date must occur after start date"
+
     Examples:
-      | tenure                               |
-      | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+      | property                             | tenureType    | startDay | startMonth | startYear | endDay | endMonth | endYear |
+      | 14a9c7de-60ea-4a79-8bf2-6d819a562bf0 | Shared Owners | 02       | 01         | 2000      | 01     | 01       | 2000    |
 
-  Scenario Outline: Cannot edit tenure for inactive or past tenures
-    When I edit a Tenure "<tenure>"
-    Then the tenure cannot be edited warning message is displayed
+Scenario Outline: Edit existing tenure
+  Given I seeded the database
+  When I view a tenure ""
+  Then the tenure information is displayed
+  And I click edit tenure
+  Then the edit tenure information is displayed
+  When I select a tenure type "<tenureType>"
+  And I click the next button
+  Then the edit tenure information is displayed
 
-    Examples:
-      | tenure                               |
-      | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+  Examples:
+    | tenureType |
+    | Freehold   |
+
+Scenario Outline: Edit existing tenure and cancel
+  Given I seeded the database
+  When I view a tenure ""
+  Then the tenure information is displayed
+  And I click edit tenure
+  Then the edit tenure information is displayed
+  When I select a tenure type "<tenureType>"
+  And I click the cancel button
+  Then the cancel modal is displayed
+  When I click the modal cancel button
+  Then the edit tenure information is displayed
+  And I click the cancel button
+  Then the cancel modal is displayed
+  And I click the confirm button
+  Then the tenure information is displayed
+
+  Examples:
+    | tenureType |
+    | Freehold   |
+
+Scenario Outline: Display Confirmation Alert pop up when ending a Tenure
+  Given I seeded the database
+  When I view a tenure ""
+  Then the tenure information is displayed
+  And I click edit tenure
+  Then the edit tenure information is displayed
+  When I select a tenure type "<tenureType>"
+  And I enter a tenure end date as "<day>" "<month>" "<year>"
+  And I click the next button
+  Then the warning modal is displayed
+  And the information text is displayed
+  When I click the modal cancel button
+  Then the edit tenure information is displayed
+  When I click the next button
+  Then the warning modal is displayed
+  When I click yes on the modal
+  Then the tenure information is displayed with the page heading Tenure updated
+
+  Examples:
+    | tenureType | day | month | year |
+    | Freehold   | 20  | 05    | 2022 |
+
+Scenario Outline: Edit tenure button is not displayed for inactive or past tenures
+  When I view a tenure "<tenure>"
+  Then the tenure information is displayed
+  And the edit tenure button is not displayed
+  Examples:
+    | tenure                               |
+    | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
+
+Scenario Outline: Cannot edit tenure for inactive or past tenures
+  When I edit a Tenure "<tenure>"
+  Then the tenure cannot be edited warning message is displayed
+
+  Examples:
+    | tenure                               |
+    | e832a76f-8bcf-238c-7ad1-6ef1b408b316 |
 
   #  @ignore
   #  Scenario Outline: Create person for new tenure validation
@@ -642,34 +582,34 @@ Feature: Create tenure
   #      | property                             | tenure                               | searchTerm | title | personType          | firstName | middleName | lastName | day | month | year |
   #      | 58815bed-8996-653d-9e98-ec5d3b68527f | 3a5114c9-1a63-4e15-953d-5b8328e84549 | emi        | Mr    | Named tenure holder | Test      | Test       | guid     | 08  | 05    | 1969 |
 
-  @regression
-  Scenario Outline: End dates are editable for all tenure types
-    Given I seeded the database
-    When I edit a Tenure ""
-    When I select a tenure type "<tenureType>"
-    Then the tenure end date is editable
+@regression
+Scenario Outline: End dates are editable for all tenure types
+  Given I seeded the database
+  When I edit a Tenure ""
+  When I select a tenure type "<tenureType>"
+  Then the tenure end date is editable
 
-    Examples:
-      | tenureType       |
-      | Freehold         |
-      | Freehold (Serv)  |
-      | Introductory     |
-      | Leasehold (RTB)  |
-      | License Temp Ac  |
-      | Lse 100% Stair   |
-      | Mesne Profit Ac  |
-      | Non-Secure       |
-      | Private Sale LH  |
-      | Rent To Mortgage |
-      | Secure           |
-      | Shared Equity    |
-      | Shared Owners    |
-      | Short Life Lse   |
-      | Temp Annex       |
-      | Temp B&B         |
-      | Temp Decant      |
-      | Temp Hostel      |
-      | Temp Hostel Lse  |
-      | Temp Private Lt  |
-      | Temp Traveller   |
-      | Tenant Acc Flat  |
+  Examples:
+    | tenureType       |
+    | Freehold         |
+    | Freehold (Serv)  |
+    | Introductory     |
+    | Leasehold (RTB)  |
+    | License Temp Ac  |
+    | Lse 100% Stair   |
+    | Mesne Profit Ac  |
+    | Non-Secure       |
+    | Private Sale LH  |
+    | Rent To Mortgage |
+    | Secure           |
+    | Shared Equity    |
+    | Shared Owners    |
+    | Short Life Lse   |
+    | Temp Annex       |
+    | Temp B&B         |
+    | Temp Decant      |
+    | Temp Hostel      |
+    | Temp Hostel Lse  |
+    | Temp Private Lt  |
+    | Temp Traveller   |
+    | Tenant Acc Flat  |

--- a/cypress/e2e/createTenure/createTenure.js
+++ b/cypress/e2e/createTenure/createTenure.js
@@ -12,7 +12,7 @@ Then('the new tenure landing page is displayed', () => {
     createTenurePage.addPropertyHeading().should('be.visible')
     createTenurePage.propertyAddress().should('be.visible')
 })
-    
+
 When('I select a tenure type {string}', (tenureType) => {
     createTenurePage.tenureTypeSelection().select(tenureType)
 })
@@ -30,7 +30,7 @@ And('I enter a tenure end date {string} {string} {string}', (day, month, year) =
 })
 
 And('I click the cancel button', () => {
-    createTenurePage.cancelButton().click({force: true})
+    createTenurePage.cancelButton().click({ force: true })
 })
 
 Then('a create tenure error is triggered {string}', (error) => {
@@ -60,7 +60,7 @@ Then('the edit tenure information is displayed', () => {
     createTenurePage.tenureStartDateDayContainer().should('be.visible')
     createTenurePage.tenureStartDateMonthContainer().should('be.visible')
     createTenurePage.tenureStartDateYearContainer().should('be.visible')
-    cy.getTenureFixture(({id: tenureId}) => {
+    cy.getTenureFixture(({ id: tenureId }) => {
         cy.url().should('include', `tenure/${tenureId}/edit`)
     })
 })
@@ -85,14 +85,15 @@ Then('the tenure cannot be edited warning message is displayed', () => {
 })
 
 When('I add {int} named tenure holder', (tenureHolders) => {
-    for(let i = 0; i < tenureHolders; i++) {
+    cy.wait(10000) // Allows enough time to retrieve tenure with the latest version
+    for (let i = 0; i < tenureHolders; i++) {
         createTenurePage.addAsNamedTenureHolderButton().eq(i).click()
     }
 })
 
 Then('the person is added to the tenure', () => {
     // createTenurePage.pageAnnouncementContainer().should('be.visible')
-     createTenurePage.pageAnnouncementContainer().should('contain', 'Person added to tenure');
+    createTenurePage.pageAnnouncementContainer().should('contain', 'Person added to tenure');
 })
 
 Then('the person is not added to the tenure', () => {
@@ -101,8 +102,9 @@ Then('the person is not added to the tenure', () => {
 })
 
 When('I add {int} household member', (householdMembers) => {
-    for(let i = 0; i < householdMembers; i++) {
-        createTenurePage.addAsHousholdMember().eq(i).click()
+    cy.wait(10000) // Allows enough time to retrieve tenure with the latest version
+    for (let i = 0; i < householdMembers; i++) {
+        createTenurePage.addAsHouseholdMember().eq(i).click()
     }
 })
 
@@ -146,7 +148,7 @@ Given('I delete all existing persons from the tenure {string}', async (tenureId)
     const householdMembers = getResponse.data.householdMembers;
 
     // DELETE any existing person from the tenure
-    for(let i = 0; i < householdMembers.length; i++) {
+    for (let i = 0; i < householdMembers.length; i++) {
         const deleteResponse = await tenure.deleteTenure(tenureId, householdMembers[i].id)
         cy.log(`Status code ${deleteResponse.status} returned`)
         assert.deepEqual(deleteResponse.status, 204)
@@ -165,7 +167,7 @@ Then('the tenure end date is editable', () => {
 });
 Then("the information text is displayed", () => {
     modal.modalBody().should('be.visible');
-    modal.modalBody().should('contain', 'Are you sure you want to change the status of the tenure to inactive? The tenure will no longer be editable.' );
+    modal.modalBody().should('contain', 'Are you sure you want to change the status of the tenure to inactive? The tenure will no longer be editable.');
 });
 
 When("I enter a tenure end date as {string} {string} {string}", (day, month, year) => {

--- a/cypress/e2e/propertyAdd.feature
+++ b/cypress/e2e/propertyAdd.feature
@@ -51,4 +51,11 @@ Feature: Property Add
         When I click on 'Create new property' button, and the POST request fails
         Then I see an error message, indicating that there was a problem creating the new asset
 
+    @SmokeTest
+    Scenario Outline: 'New property - a user is able to add, remove, edit Patch information for the new asset'
+        Given I am on the MMH 'New property' page
+        And I find the Patch field heading
+        And I see one Patch dropdown field available to start with and I select a value
+        When I click on the button to add another Patch dropdown field, I should see a new one appear, and select a value
+        When I remove the first Patch dropdown field, using the 'Remove patch' as no longer required, I should see a total of 1 Patch dropdown field
 

--- a/cypress/e2e/propertyAdd.feature
+++ b/cypress/e2e/propertyAdd.feature
@@ -56,6 +56,6 @@ Feature: Property Add
         Given I am on the MMH 'New property' page
         And I find the Patch field heading
         And I see one Patch dropdown field available to start with and I select a value
-        When I click on the button to add another Patch dropdown field, I should see a new one appear, and select a value
+        When I click on the button to add another Patch dropdown field, and select a value. 2 patches in total should be visible
         When I remove the first Patch dropdown field, using the 'Remove patch' as no longer required, I should see a total of 1 Patch dropdown field
 

--- a/cypress/e2e/propertyAdd/propertyAdd.js
+++ b/cypress/e2e/propertyAdd/propertyAdd.js
@@ -1,13 +1,18 @@
 import { When, Then, And, Given } from "@badeball/cypress-cucumber-preprocessor";
 import { baseUrl } from "../../../environment-config";
+import * as patchData from "../../fixtures/patches.json"
 
-const editPropertyAddressUrl = `${baseUrl}/property/new`
+const addPropertyAddressUrl = `${baseUrl}/property/new`
 const assetId = "065515914"
 const addressLine1 = "47 Test Road"
 const postcode = "MK40 2RF"
 
 Given("I am on the MMH 'New property' page", () => {
-    cy.visit(editPropertyAddressUrl)
+    cy.intercept('GET', `*/api/v1/patch/all`, { fixture: 'patches.json', }).as('getAllPatches')
+
+    cy.visit(addPropertyAddressUrl)
+
+    cy.wait('@getAllPatches')
 });
 
 Then("I should see the main heading 'New Property', along with the other secondary headings: Address, Property management, Asset details", () => {
@@ -88,4 +93,27 @@ When("I click on 'Create new property' button, and the POST request fails", () =
 Then("I see an error message, indicating that there was a problem creating the new asset", () => {
     cy.contains('There was a problem creating a new asset').should('be.visible')
     cy.contains('Please refresh the page and try again. If the issue persists, please contact support.').should('be.visible')
+})
+
+And("I find the Patch field heading", () => {
+    cy.contains('Patches').should('be.visible');
+})
+
+And("I see one Patch dropdown field available to start with and I select a value", () => {
+    cy.get('[data-testid="patch-dropdown-1"]').should('be.visible').and('have.value', null);
+    cy.get('[data-testid="patch-dropdown-1"]').select(patchData[1].id);
+    cy.get('[data-testid="patch-dropdown-1"]').should('have.value', patchData[1].id);
+})
+
+When("I click on the button to add another Patch dropdown field, I should see a new one appear, and select a value", () => {
+    cy.get('[data-testid="patch-add-link"]').should('be.visible');
+    cy.get('[data-testid="patch-add-link"]').click();
+    cy.get('[data-testid="patch-dropdown-2"]').should('be.visible').and('have.value', null);
+    cy.get('[data-testid="patch-dropdown-2"]').select(patchData[2].id);
+})
+
+When("I remove the first Patch dropdown field, using the 'Remove patch' as no longer required, I should see a total of 1 Patch dropdown field", () => {
+    cy.get('[data-testid="patch-remove-link-1"]').should('be.visible');
+    cy.get('[data-testid="patch-remove-link-1"]').click();
+    cy.get('[id="property-patches-container"]').children().should('have.length', 1);
 })

--- a/cypress/e2e/propertyAdd/propertyAdd.js
+++ b/cypress/e2e/propertyAdd/propertyAdd.js
@@ -105,11 +105,12 @@ And("I see one Patch dropdown field available to start with and I select a value
     cy.get('[data-testid="patch-dropdown-1"]').should('have.value', patchData[1].id);
 })
 
-When("I click on the button to add another Patch dropdown field, I should see a new one appear, and select a value", () => {
+When("I click on the button to add another Patch dropdown field, and select a value. 2 patches in total should be visible", () => {
     cy.get('[data-testid="patch-add-link"]').should('be.visible');
     cy.get('[data-testid="patch-add-link"]').click();
     cy.get('[data-testid="patch-dropdown-2"]').should('be.visible').and('have.value', null);
     cy.get('[data-testid="patch-dropdown-2"]').select(patchData[2].id);
+    cy.get('[id="property-patches-container"]').children().should('have.length', 2);
 })
 
 When("I remove the first Patch dropdown field, using the 'Remove patch' as no longer required, I should see a total of 1 Patch dropdown field", () => {

--- a/cypress/e2e/propertyAdd/propertyAdd.js
+++ b/cypress/e2e/propertyAdd/propertyAdd.js
@@ -8,7 +8,7 @@ const addressLine1 = "47 Test Road"
 const postcode = "MK40 2RF"
 
 Given("I am on the MMH 'New property' page", () => {
-    cy.intercept('GET', `*/api/v1/patch/all`, { fixture: 'patches.json', }).as('getAllPatches')
+    cy.intercept('GET', '*/api/v1/patch/all', { fixture: 'patches.json', }).as('getAllPatches')
 
     cy.visit(addPropertyAddressUrl)
 

--- a/cypress/e2e/propertyEdit.feature
+++ b/cypress/e2e/propertyEdit.feature
@@ -47,7 +47,7 @@ Feature: Property Edit
     Scenario Outline: 'Edit property address - patch address is successful'
         Given I am on the MMH 'Edit property address' page
         And I edit the address line 1 of the address
-        Then I click on 'Update to this address' button, and the PATCH request is successful
+        Then I click on 'Update to this address' button, and the PATCH requests are successful
         And I can see the address line 1 of the 'Current address' has changed successfully
         And I can see a success message at the top of the screen
         And the 'Update to this address' and 'Cancel' buttons should be replaced by the 'Back to asset view' button
@@ -56,7 +56,7 @@ Feature: Property Edit
     Scenario Outline: 'Edit property address - patch address is not successful'
         Given I am on the MMH 'Edit property address' page
         And I edit the address line 1 of the address
-        Then I click on 'Update to this address' button, and the PATCH request fails
+        Then I click on 'Update to this address' button, and the PATCH requests fail
         And I should see and error indicating that the request failed
 
     @SmokeTest

--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -65,16 +65,19 @@ And("I edit the address line 1 of the address", () => {
     cy.get('[data-testid="address-line-1"]').clear().type(newAddressLine1Value)
 })
 
-Then("I click on 'Update to this address' button, and the PATCH request is successful", () => {
+Then("I click on 'Update to this address' button, and the PATCH requests are successful", () => {
     cy.intercept('PATCH', `*/api/v1/assets/${propertyGuid}/address`, { statusCode: 204 }).as('patchAddress')
+    cy.intercept('PATCH', `*/api/v1/asset/${propertyUprn}`, { statusCode: 204 }).as('updateAssetDetails')
 
     cy.contains('Update to this address').click()
 
     cy.wait('@patchAddress')
+    cy.wait('@updateAssetDetails')
 })
 
-Then("I click on 'Update to this address' button, and the PATCH request fails", () => {
+Then("I click on 'Update to this address' button, and the PATCH requests fail", () => {
     cy.intercept('PATCH', `*/api/v1/assets/${propertyGuid}/address`, { forceNetworkError: true }).as('patchAddress')
+    cy.intercept('PATCH', `*/api/v1/asset/${propertyUprn}`, { forceNetworkError: true }).as('updateAssetDetails')
 
     cy.contains('Update to this address').click()
 

--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -82,6 +82,7 @@ Then("I click on 'Update to this address' button, and the PATCH requests fail", 
     cy.contains('Update to this address').click()
 
     cy.wait('@patchAddress')
+    cy.wait('@updateAssetDetails')
 })
 
 And("I can see the address line 1 of the 'Current address' has changed successfully", () => {

--- a/cypress/fixtures/patches.json
+++ b/cypress/fixtures/patches.json
@@ -1,0 +1,44 @@
+[
+    {
+        "id": "b4b3593c-f5d1-4ade-875f-648acefb63bf",
+        "parentId": "cd855559-c9a1-409f-948f-57bffdf4dd4c",
+        "name": "HN8",
+        "patchType": "patch",
+        "domain": "MMH",
+        "responsibleEntities": [
+            {
+                "id": "57e7a596-1851-40c6-90e6-26074b636364",
+                "name": "Fake_Gabriella Fake_Klocko",
+                "responsibleType": "HousingOfficer"
+            }
+        ]
+    },
+    {
+        "id": "d32b8c9e-a66d-4c29-a283-892cab6b7cf2",
+        "parentId": "131d9da4-07a3-432a-85b8-2588ba270907",
+        "name": "SD9",
+        "patchType": "patch",
+        "domain": "MMH",
+        "responsibleEntities": [
+            {
+                "id": "90a2777f-8a24-4922-9648-1bae7ce45c22",
+                "name": "Fake_Isabella Fake_Kulas",
+                "responsibleType": "HousingOfficer"
+            }
+        ]
+    },
+    {
+        "id": "19186680-5dc8-49a8-8916-e8c8bcffbefd",
+        "parentId": "00f32090-68d5-49f6-950d-eba5b94c6f54",
+        "name": "HN1 Area",
+        "patchType": "area",
+        "domain": "MMH",
+        "responsibleEntities": [
+            {
+                "id": "240b0ea4-5f18-4066-8fa4-159fce959062",
+                "name": "Fake_Devan Fake_Cruickshank",
+                "responsibleType": "HousingOfficer"
+            }
+        ]
+    }
+]

--- a/cypress/pageObjects/createTenurePage.js
+++ b/cypress/pageObjects/createTenurePage.js
@@ -91,8 +91,8 @@ class CreateTenurePageObjects {
         return cy.contains('Add as named tenure holder')
     }
 
-    addAsHousholdMember() {
-        return cy.contains('Add as household member')
+    addAsHouseholdMember() {
+        return cy.get('.govuk-button.lbh-button:contains("Add as household member")');
     }
 
     pageAnnouncementContainer() {


### PR DESCRIPTION
Added test for new Patches field added to MMH's New Asset form

See PR https://github.com/LBHackney-IT/mtfh-frontend-property/pull/76 for more details

After adding the tests related to the new Patch fields I noticed issues with other E2E tests, specifically with createTenure.feature tests. PR #293 was a temporary PR, with its own branch, created to address the createTenure tests issues. All createTenure tests were successful prior to merging branch `angelo/create-tenure-e2e-tests` back into this branch. 

Notes: 
- beforeEach and afterEach have been added so that test data added to DynamoDb is cleared before and after each test.
- added intercept to propertyEdit test to intercept 2nd API call fired after an asset is edited
- There still seems to be some (inconsistent) flakiness, with other .feature files. This may be due to the fact the E2E tests run in parallel.