### PR TITLE
PropertyEdit - Intercept and wait for PATCH Address request

### DIFF
--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -54,7 +54,12 @@ And("I edit the address line 1 of the address", () => {
 })
 
 Then("I click on 'Update to this address' button, and the PATCH requests are successful", () => {
-    cy.contains('Update to this address').click()
+    cy.getAssetFixture().then(asset => {
+        cy.intercept('PATCH', `*/api/v1/assets/${asset.id}/address`).as('patchAddress')
+        cy.intercept('PATCH', `*api/v1/asset/${asset.assetId}`).as('updateAssetDetails')
+
+        cy.contains('Update to this address').click()
+    })
 })
 
 Then("I click on 'Update to this address' button, and the PATCH requests fail", () => {
@@ -67,6 +72,7 @@ Then("I click on 'Update to this address' button, and the PATCH requests fail", 
 })
 
 And("I can see the address line 1 of the 'Current address' has changed successfully", () => {
+    cy.wait('@patchAddress')
     cy.get('[data-testid="asset-address-line-one"]').should('have.value', newAddressLine1Value)
 })
 


### PR DESCRIPTION
It seems that an assertion in a PropertyEdit test may require a hardcoded cy.wait, as this may happen before the PATCH address request is resolved, meaning the assertion will fail

- intercepted PATCH request
- added cy.wait prior to making the assertion

![image](https://github.com/LBHackney-IT/mtfh-tl-e2e-tests/assets/70756861/b2d403dd-fdd9-4ed5-913f-670afca77677)
