### PR TITLE
PropertyAdd - Added manual scroll to top before assertion

### DIFF
--- a/cypress/e2e/propertyAdd/propertyAdd.js
+++ b/cypress/e2e/propertyAdd/propertyAdd.js
@@ -91,6 +91,7 @@ When("I click on 'Create new property' button, and the POST request is successfu
 })
 
 Then("I see a success message, indicating that the asset has been created successfully", () => {
+    cy.scrollTo('top');
     cy.contains('The new asset address has been successfully added.').should('be.visible')
 })
 

--- a/cypress/e2e/propertyAdd/propertyAdd.js
+++ b/cypress/e2e/propertyAdd/propertyAdd.js
@@ -91,7 +91,6 @@ When("I click on 'Create new property' button, and the POST request is successfu
 })
 
 Then("I see a success message, indicating that the asset has been created successfully", () => {
-    cy.wait('@createNewAssetSuccess')
     cy.scrollTo('top');
     cy.contains('The new asset address has been successfully added.').should('be.visible')
 })

--- a/cypress/e2e/propertyAdd/propertyAdd.js
+++ b/cypress/e2e/propertyAdd/propertyAdd.js
@@ -91,6 +91,7 @@ When("I click on 'Create new property' button, and the POST request is successfu
 })
 
 Then("I see a success message, indicating that the asset has been created successfully", () => {
+    cy.wait('@createNewAssetSuccess')
     cy.scrollTo('top');
     cy.contains('The new asset address has been successfully added.').should('be.visible')
 })


### PR DESCRIPTION
It seems that, when the test runs on Circle CI, the assertion cannot see the success message at the very top of the page.

This PR adds a manual scroll to the top of the page, to make sure the success message is in view.

![image](https://github.com/LBHackney-IT/mtfh-tl-e2e-tests/assets/70756861/13a91454-4de4-4237-befd-533c82f02cb4)

