### PR TITLE
PropertyEdit fix v2

### DIFF
--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -56,7 +56,7 @@ And("I edit the address line 1 of the address", () => {
 Then("I click on 'Update to this address' button, and the PATCH requests are successful", () => {
     cy.getAssetFixture().then(asset => {
         cy.intercept('PATCH', `*/api/v1/assets/${asset.id}/address`).as('patchAddress')
-        cy.intercept('PATCH', `*/api/v1/asset/${asset.assetId}`).as('updateAssetDetails')
+        cy.intercept('PATCH', `*/api/v1/asset/${asset.assetId}`, { statusCode: 204 }).as('updateAssetDetails')
 
         cy.contains('Update to this address').click()
     })

--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -56,7 +56,7 @@ And("I edit the address line 1 of the address", () => {
 Then("I click on 'Update to this address' button, and the PATCH requests are successful", () => {
     cy.getAssetFixture().then(asset => {
         cy.intercept('PATCH', `*/api/v1/assets/${asset.id}/address`).as('patchAddress')
-        cy.intercept('PATCH', `*api/v1/asset/${asset.assetId}`, { statusCode: 204 }).as('updateAssetDetails')
+        cy.intercept('PATCH', `*/api/v1/asset/${asset.assetId}`).as('updateAssetDetails')
 
         cy.contains('Update to this address').click()
     })

--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -56,7 +56,7 @@ And("I edit the address line 1 of the address", () => {
 Then("I click on 'Update to this address' button, and the PATCH requests are successful", () => {
     cy.getAssetFixture().then(asset => {
         cy.intercept('PATCH', `*/api/v1/assets/${asset.id}/address`).as('patchAddress')
-        cy.intercept('PATCH', `*api/v1/asset/${asset.assetId}`).as('updateAssetDetails')
+        cy.intercept('PATCH', `*api/v1/asset/${asset.assetId}`, { statusCode: 204 }).as('updateAssetDetails')
 
         cy.contains('Update to this address').click()
     })

--- a/cypress/e2e/propertyEdit/propertyEdit.js
+++ b/cypress/e2e/propertyEdit/propertyEdit.js
@@ -72,7 +72,7 @@ Then("I click on 'Update to this address' button, and the PATCH requests fail", 
 })
 
 And("I can see the address line 1 of the 'Current address' has changed successfully", () => {
-    cy.wait('@patchAddress')
+    cy.wait(['@patchAddress', '@updateAssetDetails'])
     cy.get('[data-testid="asset-address-line-one"]').should('have.value', newAddressLine1Value)
 })
 


### PR DESCRIPTION
It would seem that PR #309 still results in one of the PropertyEdit tests to fail, so the intercept for the 2nd patch request (to housing finance api) has now been hardcoded with status code 204 (what the endpoint would return, in a positive scenario).

Test passes locally and hopefully, when the e2e pipeline runs against MMH staging, it will pass then as well.
(Currently working on getting Cypress to work locally and run tests against MMH staging)