### PR TITLE
Tech Debt - Fixed tenure.feature mobile device tests

### DIFF
--- a/cypress/e2e/tenure.feature
+++ b/cypress/e2e/tenure.feature
@@ -9,50 +9,50 @@ Feature: Tenure page
     Background:
         Given I am logged in
 
-    Scenario: View resident details for new tenure
-        Given I seeded the database with a tenure
-        When I view a tenure
-        Then the tenure information is displayed
-        And the residents information is displayed
+    # Scenario: View resident details for new tenure
+    #     Given I seeded the database with a tenure
+    #     When I view a tenure
+    #     Then the tenure information is displayed
+    #     And the residents information is displayed
 
-    Scenario Outline: Navigate to old tenancy files
-        Given I create a tenure that started on date "2013-12-31", with no responsible household members
-        And the start date for the tenure record is before 31 December 2013
-        When I view a tenure
-        Then the Scanned historic tenure records button is displayed
+    # Scenario Outline: Navigate to old tenancy files
+    #     Given I create a tenure that started on date "2013-12-31", with no responsible household members
+    #     And the start date for the tenure record is before 31 December 2013
+    #     When I view a tenure
+    #     Then the Scanned historic tenure records button is displayed
 
-    @SmokeTest
-    Scenario Outline: Navigate to old tenancy files - button not displayed
-        Given I create a tenure that started on date "2014-12-31", with no responsible household members
-        And the start date for the tenure record is after 31 December 2013
-        When I view a tenure
-        Then the Scanned historic tenure records button is not displayed
+    # @SmokeTest
+    # Scenario Outline: Navigate to old tenancy files - button not displayed
+    #     Given I create a tenure that started on date "2014-12-31", with no responsible household members
+    #     And the start date for the tenure record is after 31 December 2013
+    #     When I view a tenure
+    #     Then the Scanned historic tenure records button is not displayed
 
-    Scenario: View household member
-        Given I seeded the database with a tenure
-        When I view a tenure
-        When I view the Other household members section in the tenure page
-        And I select a household member
-        Then the household member details are displayed
+    # Scenario: View household member
+    #     Given I seeded the database with a tenure
+    #     When I view a tenure
+    #     When I view the Other household members section in the tenure page
+    #     And I select a household member
+    #     Then the household member details are displayed
 
-    Scenario: No household members
-        Given I create a tenure that started on date "2014-12-31", with no responsible household members
-        When I view a tenure
-        When I view the Other household members section in the tenure page
-        And A message says this tenure has no household members
+    # Scenario: No household members
+    #     Given I create a tenure that started on date "2014-12-31", with no responsible household members
+    #     When I view a tenure
+    #     When I view the Other household members section in the tenure page
+    #     And A message says this tenure has no household members
 
-    @SmokeTest
-    Scenario: Navigate to personal details
-        Given I seeded the database with a tenure
-        When I view a tenure
-        And I select a resident
-        Then the resident details are displayed
+    # @SmokeTest
+    # Scenario: Navigate to personal details
+    #     Given I seeded the database with a tenure
+    #     When I view a tenure
+    #     And I select a resident
+    #     Then the resident details are displayed
 
     # These tests seem to pass consistently in Circle CI, however when running locally, the Tenure Accordion cannot be found at times,
     # and the tests have flaky results. We're currently (06/07/23) working on getting consistent passes on all MMH tests,
     # and as I can't guaranteee these tests will never cause any flakiness on the Circle CI pipeline, I'm currently commenting these out (Angelo).
     @device
-    Scenario Outline: Mobile view
+    Scenario Outline: Mobile view - Devices with smaller screens
         Given I seeded the database with a tenure
         And I view a tenure
         When I am using a mobile viewport "<device>"
@@ -63,8 +63,6 @@ Feature: Tenure page
 
         Examples:
             | device      |
-            # | ipad-2        |
-            # | ipad-mini   |
             | iphone-3    |
             | iphone-4    |
             | iphone-5    |
@@ -75,15 +73,30 @@ Feature: Tenure page
             | iphone-x    |
             | iphone-xr   |
             | iphone-se2  |
-            # | macbook-11    |
-            # | macbook-13    |
-            # | macbook-15    |
-            # | macbook-16    |
-            # | samsung-note9 |
             | samsung-s10 |
 
-    @Accessibility
-    Scenario: Accessibility Testing
+    @device
+    Scenario Outline: Mobile view - Devices with bigger screens
         Given I seeded the database with a tenure
-        When I view a tenure
-        And have no detectable a11y violations
+        And I view a tenure
+        When I am using a mobile viewport "<device>"
+        Then the tenure details accordion information is displayed
+        Then the residents details accordion information is displayed
+
+        Examples:
+            | device        |
+            | ipad-2        |
+            | ipad-mini     |
+            | macbook-11    |
+            | macbook-13    |
+            | macbook-15    |
+            | macbook-16    |
+            | samsung-note9 |
+
+
+
+# @Accessibility
+# Scenario: Accessibility Testing
+#     Given I seeded the database with a tenure
+#     When I view a tenure
+#     And have no detectable a11y violations

--- a/cypress/e2e/tenure.feature
+++ b/cypress/e2e/tenure.feature
@@ -9,48 +9,45 @@ Feature: Tenure page
     Background:
         Given I am logged in
 
-    # Scenario: View resident details for new tenure
-    #     Given I seeded the database with a tenure
-    #     When I view a tenure
-    #     Then the tenure information is displayed
-    #     And the residents information is displayed
+    Scenario: View resident details for new tenure
+        Given I seeded the database with a tenure
+        When I view a tenure
+        Then the tenure information is displayed
+        And the residents information is displayed
 
-    # Scenario Outline: Navigate to old tenancy files
-    #     Given I create a tenure that started on date "2013-12-31", with no responsible household members
-    #     And the start date for the tenure record is before 31 December 2013
-    #     When I view a tenure
-    #     Then the Scanned historic tenure records button is displayed
+    Scenario Outline: Navigate to old tenancy files
+        Given I create a tenure that started on date "2013-12-31", with no responsible household members
+        And the start date for the tenure record is before 31 December 2013
+        When I view a tenure
+        Then the Scanned historic tenure records button is displayed
 
-    # @SmokeTest
-    # Scenario Outline: Navigate to old tenancy files - button not displayed
-    #     Given I create a tenure that started on date "2014-12-31", with no responsible household members
-    #     And the start date for the tenure record is after 31 December 2013
-    #     When I view a tenure
-    #     Then the Scanned historic tenure records button is not displayed
+    @SmokeTest
+    Scenario Outline: Navigate to old tenancy files - button not displayed
+        Given I create a tenure that started on date "2014-12-31", with no responsible household members
+        And the start date for the tenure record is after 31 December 2013
+        When I view a tenure
+        Then the Scanned historic tenure records button is not displayed
 
-    # Scenario: View household member
-    #     Given I seeded the database with a tenure
-    #     When I view a tenure
-    #     When I view the Other household members section in the tenure page
-    #     And I select a household member
-    #     Then the household member details are displayed
+    Scenario: View household member
+        Given I seeded the database with a tenure
+        When I view a tenure
+        When I view the Other household members section in the tenure page
+        And I select a household member
+        Then the household member details are displayed
 
-    # Scenario: No household members
-    #     Given I create a tenure that started on date "2014-12-31", with no responsible household members
-    #     When I view a tenure
-    #     When I view the Other household members section in the tenure page
-    #     And A message says this tenure has no household members
+    Scenario: No household members
+        Given I create a tenure that started on date "2014-12-31", with no responsible household members
+        When I view a tenure
+        When I view the Other household members section in the tenure page
+        And A message says this tenure has no household members
 
-    # @SmokeTest
-    # Scenario: Navigate to personal details
-    #     Given I seeded the database with a tenure
-    #     When I view a tenure
-    #     And I select a resident
-    #     Then the resident details are displayed
+    @SmokeTest
+    Scenario: Navigate to personal details
+        Given I seeded the database with a tenure
+        When I view a tenure
+        And I select a resident
+        Then the resident details are displayed
 
-    # These tests seem to pass consistently in Circle CI, however when running locally, the Tenure Accordion cannot be found at times,
-    # and the tests have flaky results. We're currently (06/07/23) working on getting consistent passes on all MMH tests,
-    # and as I can't guaranteee these tests will never cause any flakiness on the Circle CI pipeline, I'm currently commenting these out (Angelo).
     @device
     Scenario Outline: Mobile view - Devices with smaller screens
         Given I seeded the database with a tenure
@@ -93,10 +90,8 @@ Feature: Tenure page
             | macbook-16    |
             | samsung-note9 |
 
-
-
-# @Accessibility
-# Scenario: Accessibility Testing
-#     Given I seeded the database with a tenure
-#     When I view a tenure
-#     And have no detectable a11y violations
+    @Accessibility
+    Scenario: Accessibility Testing
+        Given I seeded the database with a tenure
+        When I view a tenure
+        And have no detectable a11y violations


### PR DESCRIPTION
Some of the devices in one of the tests in `tenure.feature` file were commented out as their tests were not passing. 

This is because these devices have bigger screens than the other devices listed, and yet the test itself was not accounting for their bigger screen size, and it was looking for some accordion HTML elements that only appear for devices with smaller screens.

The one test now has been split into 2 tests, one for small screens and one for bigger screens.