### PR TITLE
MR-760 - Amend tests to reflect the change made on the selection of contact type

### DIFF
--- a/cypress/e2e/addPerson.feature
+++ b/cypress/e2e/addPerson.feature
@@ -146,9 +146,6 @@ Feature: Add a new person to a tenure
     And I click edit person
     And I click cancel
     Then the confirmation modal is displayed
-  @Accessibility
-  Scenario: Accessibility Testing
-    And have no detectable a11y violations
 
   #    @ignore
   #    Scenario Outline: Correspondence address using valid postcode lookup details

--- a/cypress/e2e/common/common.js
+++ b/cypress/e2e/common/common.js
@@ -398,30 +398,6 @@ And("I enter a phone number {string}", (phoneNumber) => {
   personContactPage.phoneNumberField().type(phoneNumber);
 });
 
-And("I select a phone number type {string}", (phoneType) => {
-  switch (phoneType) {
-    case "Mobile":
-      personContactPage.phoneNumberMobileType().click();
-      break;
-
-    case "Work":
-      personContactPage.phoneNumberWorkType().click();
-      break;
-
-    case "Home":
-      personContactPage.phoneNumberHomeType().click();
-      break;
-
-    case "Other":
-      personContactPage.phoneNumberOtherType().click();
-      break;
-
-    default:
-      cy.log("Please select a valid phone number type");
-      break;
-  }
-});
-
 And("I enter a phone number description {string}", (phoneDescription) => {
   personContactPage.phoneNumberDescription().type(phoneDescription);
 });
@@ -903,7 +879,7 @@ When("I enter data email address and phone number", () => {
   //cy.contains(`Email address: ${emailAdd}`);
   cy.contains('Add a phone number').click();
   cy.get('#contact-details-phone-number-field').type(phoneNumber);
-  cy.get('#contact-details-phone-type-mobile').click();
+  cy.get('#contact-details-phone-type-field').select("Main number")
   cy.contains('Save phone number').click();
   changeOfName.buttonReturnToApplication().click();
 });

--- a/cypress/e2e/tenureRequestAndReviewDocuments.feature
+++ b/cypress/e2e/tenureRequestAndReviewDocuments.feature
@@ -139,13 +139,3 @@ Feature: As an internal Hackney user
         And the status is Finish
         And I click on Continue button
         And I can see the text 'I confirm that the tenure investigation has been completed'
-
-
-
-
-
-
-
-
-
-

--- a/cypress/pageObjects/personContactPage.js
+++ b/cypress/pageObjects/personContactPage.js
@@ -46,24 +46,8 @@ class PersonContactPageObjects {
         return cy.get('#contact-details-phone-number-field')
     }
 
-    phoneNumberMobileType() {
-        return cy.get('#contact-details-phone-type-mobile')
-    }
-
     phoneNumberContactTypeMainNumber() {
         return cy.get('#contact-details-phone-type-field').select("Main number")
-    }
-
-    phoneNumberHomeType() {
-        return cy.get('#contact-details-phone-type-home')
-    }
-
-    phoneNumberWorkType() {
-        return cy.get('#contact-details-phone-type-work')
-    }
-
-    phoneNumberOtherType() {
-        return cy.get('#contact-details-phone-type-other')
     }
 
     phoneNumberDescription() {

--- a/cypress/pageObjects/personContactPage.js
+++ b/cypress/pageObjects/personContactPage.js
@@ -50,6 +50,10 @@ class PersonContactPageObjects {
         return cy.get('#contact-details-phone-type-mobile')
     }
 
+    phoneNumberContactTypeMainNumber() {
+        return cy.get('#contact-details-phone-type-field').select("Main number")
+    }
+
     phoneNumberHomeType() {
         return cy.get('#contact-details-phone-type-home')
     }
@@ -168,7 +172,7 @@ class PersonContactPageObjects {
     addPhoneNumber(value, description) {
         this.addPhoneNumberButton().click()
         this.phoneNumberField().type(value)
-        this.phoneNumberMobileType().click()
+        this.phoneNumberContactTypeMainNumber()
         this.phoneNumberDescription().type(description)
         this.savePhoneNumberButton().click()
     }


### PR DESCRIPTION
The way a user adds a contact for a person/resident has changed in MMH (see [PR](https://github.com/LBHackney-IT/mtfh-frontend-personal-details/pull/121))

Specifically, now the user has to select a "contact type" from a dropdown menu (of more specific/descriptive options). The radio options have been removed as not descriptive enough.

In this PR I've changed the code accordingly, and I've removed some no longer required code.