### PR TITLE
Set cypress-browsers resource class to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ executors:
     cypress-browsers:
         docker:
             - image: cypress/browsers:node16.13.2-chrome100-ff98
+        resource_class: large
 
 commands:
     assume-role-and-persist-workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ executors:
     cypress-browsers:
         docker:
             - image: cypress/browsers:node16.13.2-chrome100-ff98
-        resource_class: large
+        resource_class: medium+
 
 commands:
     assume-role-and-persist-workspace:


### PR DESCRIPTION
This is to try to fix flakiness experienced by the Cypress tests when ran on CI, which is suspected to be due to an insufficiently provisioned executor class