### PR TITLE
Revert "Set cypress-browsers resource class to medium+"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ executors:
     cypress-browsers:
         docker:
             - image: cypress/browsers:node16.13.2-chrome100-ff98
-        resource_class: medium+
 
 commands:
     assume-role-and-persist-workspace:


### PR DESCRIPTION
Revert the docker instance size to medium as it doesn't help with the flakiness of the tests or the time it takes. 