### PR TITLE
Extend change of name year

### DIFF
--- a/cypress/e2e/changeOfName/changeOfName.js
+++ b/cypress/e2e/changeOfName/changeOfName.js
@@ -68,7 +68,7 @@ When("I select 'I have made an appointment to check supporting documents' and cl
     tenureReqDocsPage.makeAnAppointToCheckSuppDocs().click();
     tenureReqDocsPage.day().type('31');
     tenureReqDocsPage.month().type('12');
-    tenureReqDocsPage.year().type('2023')
+    tenureReqDocsPage.year().type('2100')
     tenureReqDocsPage.hour().type('11');
     tenureReqDocsPage.minute().type('20');
     tenureReqDocsPage.ampm().select('AM');


### PR DESCRIPTION
Test was faling because 31/12/2023 is now in the past and appointment date needs to be in the future