### PR TITLE
Fixed incorrect Cypress grep tagging syntax, and disabled the fixture filtering optimisation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
                           [ "<<parameters.trigger-context>>" = "external" ] && [ "<<parameters.stage>>" = "production" ] && export CYPRESS_grepTags="$CYPRESS_grepTags @Production"
 
                           if [ -n "$PIPELINE_FILTER" ]; then
-                            ( [ $PIPELINE_FILTER = "common" ] || [ $PIPELINE_FILTER = "authentication" ] || [ $PIPELINE_FILTER = "root" ] ) && export PIPELINE_FILTER="@SmokeTest"
+                            ( [ $PIPELINE_FILTER = "common" ] || [ $PIPELINE_FILTER = "authentication" ] || [ $PIPELINE_FILTER = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
                             export CYPRESS_grepTags="$CYPRESS_grepTags @$PIPELINE_FILTER"
                           fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
                           [ "<<parameters.trigger-context>>" = "external" ] && [ "<<parameters.stage>>" = "production" ] && export CYPRESS_grepTags="$CYPRESS_grepTags @Production"
 
                           if [ -n "$PIPELINE_FILTER" ]; then
-                            ( [ $PIPELINE_FILTER = "common" ] || [ $PIPELINE_FILTER = "authentication" ] || [ $PIPELINE_FILTER = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
+                            ( [ "$PIPELINE_FILTER" = "common" ] || [ "$PIPELINE_FILTER" = "authentication" ] || [ "$PIPELINE_FILTER" = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
                             export CYPRESS_grepTags="$CYPRESS_grepTags @$PIPELINE_FILTER"
                           fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
                           export CYPRESS_AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile default) ;
                           export CYPRESS_AWS_SESSION_TOKEN=$(aws configure get aws_session_token --profile default) ;
                           
-                          export CYPRESS_grepTags='--@GoogleLighthouse --@Accessibility --@ignore' ;
+                          export CYPRESS_grepTags='-@GoogleLighthouse -@Accessibility -@ignore' ;
                           export PIPELINE_FILTER="$(echo << pipeline.parameters.upstream_pipeline_name >> | sed 's,https://github.com/LBHackney-IT/mtfh-frontend-,,g')"
                           [ "<<parameters.trigger-context>>" = "external" ] && [ "<<parameters.stage>>" = "production" ] && export CYPRESS_grepTags="$CYPRESS_grepTags @Production"
 
@@ -109,7 +109,7 @@ commands:
                           if [ "<<parameters.trigger-context>>" = "devices" ]; then
                             export CYPRESS_grepTags="$CYPRESS_grepTags @device"
                           else
-                            export CYPRESS_grepTags="$CYPRESS_grepTags --@device"
+                            export CYPRESS_grepTags="$CYPRESS_grepTags -@device"
                           fi              
                           
                           npm install ;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
                           [ "<<parameters.trigger-context>>" = "external" ] && [ "<<parameters.stage>>" = "production" ] && export CYPRESS_grepTags="$CYPRESS_grepTags @Production"
 
                           if [ -n "$PIPELINE_FILTER" ]; then
-                            [ $PIPELINE_FILTER = "common" ] || [ $PIPELINE_FILTER = "authentication" ] || [ $PIPELINE_FILTER = "root" ] && export PIPELINE_FILTER="@SmokeTest"
+                            ( [ $PIPELINE_FILTER = "common" ] || [ $PIPELINE_FILTER = "authentication" ] || [ $PIPELINE_FILTER = "root" ] ) && export PIPELINE_FILTER="@SmokeTest"
                             export CYPRESS_grepTags="$CYPRESS_grepTags @$PIPELINE_FILTER"
                           fi
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,7 +27,9 @@ module.exports = defineConfig({
     numTestsKeptInMemory: 25,
     supportFile: 'cypress/support/e2e.js',
     env: {
-        grepFilterSpecs: true,
+        // While 'grepFilterSpecs' gives performance boost by preventing the load of specs,
+        // it's not compatible with the exclusion pattern 'inverted filters' (see cypress grep docs for more info) 
+        //grepFilterSpecs: true,
         grepOmitFiltered: true
     }
   },

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,9 +27,6 @@ module.exports = defineConfig({
     numTestsKeptInMemory: 25,
     supportFile: 'cypress/support/e2e.js',
     env: {
-        // While 'grepFilterSpecs' gives performance boost by preventing the load of specs,
-        // it's not compatible with the exclusion pattern 'inverted filters' (see cypress grep docs for more info) 
-        //grepFilterSpecs: true,
         grepOmitFiltered: true
     }
   },


### PR DESCRIPTION
# What:
 - Fix the incorrect syntax for 'Inverted Filters'.
 - Fix the incorrect syntax for conditionally appended 'SmokeTest' tag.
 - Disable spec filtering optimisation to get the 'Inverted Filters' functionality working again.

# Why:
 - When `mtfh-frontend-common` triggers a test run, tests suites run, but zero tests are actually executed. As a result, the test run passes since zero out of zero tests passed _(there are no failures)_. The introduced changes hopefully will fix that.

# Notes:
 - Currently, a few tests are guaranteed to fail. It's a small amount ~3 or so. Haven't looked into the details of why yet - it could be technical debt, flake, or simply the new Cognito related changes are not compatible with what the tests expect. This will get sorted in the future PRs.
 - The `grepFilterSpecs` filtering is not compatible with the `Inverted Filters` used by the pipeline. This option merely being an optimisation on tests' load times means it can be safely disabled. What's actually happening now is that instead of tests getting filtered out before the tests load, the tests now get loaded into the browser regardless of whether they're meant to run given the tags, and only then the filtering happens within the browser. Read more in official [docs](https://www.npmjs.com/package/@cypress/grep).