### PR TITLE
Skip the conflicting test whose @ignore tag is not being acknowledged for some reason.

### DIFF
--- a/cypress/e2e/createEditTenure.cy.js
+++ b/cypress/e2e/createEditTenure.cy.js
@@ -104,7 +104,10 @@ describe('create and edit tenure', { tags: ['@tenure', '@authentication', '@comm
 
     })
 
-    it('should validate on create new tenure', {tags: '@ignore'}, () => {
+    // This test conflicts with the one before it. If you were to disable the test above, this would pass.
+    // Might be why this test got ignored. It's puzzling for why this test is triggering regardless of the @ignore tag.
+    // As such, skipping this until the state conflict between the 2 tests gets resolved.
+    it.skip('should validate on create new tenure', {tags: '@ignore'}, () => {
         cy.getAssetFixture().then(({ id: tenureId }) => {
             createTenurePage.createTenure(tenureId);
 


### PR DESCRIPTION
# What:
 - Explicitly skip the "Create an Edit Tenure" new tenure validation tests.

# Why:
 - This test conflicts with the test before it. From my testing, if I skip the tests before this one, this one passes. So clearly, it's a case of a state conflict between what's being tested. Seeing that this test has an "@ignore" tag, this conflict might be the reason why.

# Notes:
 - For some reason the "@ignore" tag is being sometimes ignored. Might be something we'll want to look into in the future.