### PR TITLE
SSI-1093 skip property comments device tests

### DIFF
--- a/cypress/e2e/property-comments.cy.js
+++ b/cypress/e2e/property-comments.cy.js
@@ -112,7 +112,7 @@ describe('View property page', {tags: ['@property', '@authentication', '@common'
         })
    })
    device.forEach((test) => {
-        it('should create a comment for property on a device', {tags: '@device'}, ()=> {
+        it.skip('should create a comment for property on a device', {tags: '@device'}, ()=> {
             cy.getAssetFixture().then((property) => {
                 propertyCommentsPage.visit(property.id)
 


### PR DESCRIPTION
Disable these failing tests temporarily while we troubleshoot the issue with cautionary alerts API. This ensure the pipeline fails faster and also runs quick enough for the token to not expire.