### PR TITLE
SSI-1163 Re-enable tests after cautionary alerts api fix

### DIFF
--- a/cypress/e2e/changeAssetOwnership.cy.js
+++ b/cypress/e2e/changeAssetOwnership.cy.js
@@ -10,7 +10,7 @@ describe('Change Asset Ownership', {tags: ['@property', '@authentication', '@com
         seedDatabase();
     });
 
-    it.skip('should access form from asset page', ()=> {
+    it('should access form from asset page', ()=> {
         cy.getAssetFixture().then((asset) => {
             propertyPage.visit(asset.id);
 

--- a/cypress/e2e/property-comments.cy.js
+++ b/cypress/e2e/property-comments.cy.js
@@ -43,7 +43,7 @@ describe('View property page', {tags: ['@property', '@authentication', '@common'
         });
     })
 
-    it.skip('should create comment for property', {tags:'@SmokeTest'},()=> {
+    it('should create comment for property', {tags:'@SmokeTest'},()=> {
         cy.getAssetFixture().then((asset) => {
             propertyCommentsPage.visit(asset.id);
 
@@ -112,7 +112,7 @@ describe('View property page', {tags: ['@property', '@authentication', '@common'
         })
    })
    device.forEach((test) => {
-        it.skip('should create a comment for property on a device', {tags: '@device'}, ()=> {
+        it('should create a comment for property on a device', {tags: '@device'}, ()=> {
             cy.getAssetFixture().then((property) => {
                 propertyCommentsPage.visit(property.id)
 


### PR DESCRIPTION
The issue with the cautionary alerts API has been fixed, so the `should access form from asset page` test can be enaled again. It was previously disabled because the API threw an error due to payload issues.

Also enable the previously flaky `should create comment for property`. This will be reviewed if it's causing issues later.

Also enables the device tests that were disabled to get faster feedback loop in the pipeline.