### PR TITLE
SSI-1166 Fix tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,24 +118,26 @@ commands:
                           export CYPRESS_AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile default) ;
                           export CYPRESS_AWS_SESSION_TOKEN=$(aws configure get aws_session_token --profile default) ;
                           
-                          export CYPRESS_grepTags='-@GoogleLighthouse -@Accessibility -@ignore' ;
-                          export PIPELINE_FILTER="$(echo << pipeline.parameters.upstream_pipeline_name >> | sed 's,https://github.com/LBHackney-IT/mtfh-frontend-,,g')"
-                          [ "<<parameters.trigger-context>>" = "external" ] && [ "<<parameters.stage>>" = "production" ] && export CYPRESS_grepTags="$CYPRESS_grepTags @Production"
-
-                          if [ -n "$PIPELINE_FILTER" ]; then
-                            ( [ "$PIPELINE_FILTER" = "common" ] || [ "$PIPELINE_FILTER" = "authentication" ] || [ "$PIPELINE_FILTER" = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
-                            export CYPRESS_grepTags="$CYPRESS_grepTags @$PIPELINE_FILTER"
+                          if [ "<<parameters.trigger-context>>" = "external" ] && [ "<<parameters.stage>>" = "production" ]; then
+                            # Production runs only @Production-tagged tests (home.cy.js); no MFE/smoke filter.
+                            export GREP_TAGS='@Production+-@ignore+-@device'
+                            export CYPRESS_SPEC='cypress/e2e/home.cy.js'
+                          elif [ "<<parameters.trigger-context>>" = "devices" ]; then
+                            export GREP_TAGS='-@GoogleLighthouse+-@Accessibility+-@ignore+@device'
+                          else
+                            export GREP_TAGS='-@GoogleLighthouse+-@Accessibility+-@ignore+-@device'
+                            export PIPELINE_FILTER="$(echo << pipeline.parameters.upstream_pipeline_name >> | sed 's,https://github.com/LBHackney-IT/mtfh-frontend-,,g')"
+                            if [ -n "$PIPELINE_FILTER" ]; then
+                              ( [ "$PIPELINE_FILTER" = "common" ] || [ "$PIPELINE_FILTER" = "authentication" ] || [ "$PIPELINE_FILTER" = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
+                              export GREP_TAGS="$GREP_TAGS+@$PIPELINE_FILTER"
+                            fi
                           fi
 
-                          if [ "<<parameters.trigger-context>>" = "devices" ]; then
-                            export CYPRESS_grepTags="$CYPRESS_grepTags @device"
-                          else
-                            export CYPRESS_grepTags="$CYPRESS_grepTags -@device"
-                          fi              
-                          
                           npm ci ;
-                          echo "Running against $CYPRESS_ENVIRONMENT environment with tags $CYPRESS_grepTags" ;
-                          ./node_modules/.bin/cypress run
+                          echo "Running against $CYPRESS_ENVIRONMENT environment with tags $GREP_TAGS" ;
+                          CYPRESS_ARGS=(run --expose "grepTags=${GREP_TAGS},grepFilterSpecs=true,grepOmitFiltered=true")
+                          [ -n "$CYPRESS_SPEC" ] && CYPRESS_ARGS+=(--spec "$CYPRESS_SPEC")
+                          ./node_modules/.bin/cypress "${CYPRESS_ARGS[@]}"
                        
             - store_artifacts:
                 path: /root/project/cypress/videos/

--- a/README.md
+++ b/README.md
@@ -62,14 +62,100 @@ Start a local test run by using `npm run test:cypress:run`
 Open the Cypress runner console by using `npm run test:cypress:open`
 
 #### Feature tags
-The e2e tests use feature tags in order to run scoped tests. They can be set within a feature file using `@featureTag` and then ran using `cypress run -e grepTags='@featureTag'` more detailed documents can be found [here](https://www.npmjs.com/package/@cypress/grep#filter-with-tags).
+
+The e2e tests use tags to scope which tests run in a given pipeline or local command. Tags are set on `describe` or `it` blocks in `.cy.js` files, for example:
+
+```js
+describe('Person page', { tags: ['@personal-details', '@authentication', '@common', '@root'] }, () => {
+  it('should view person details page', { tags: '@SmokeTest' }, () => { /* ... */ });
+});
+```
+
+#### How tag filtering works (Cypress 15 + `@cypress/grep` v6)
+
+`@cypress/grep` v6 reads tag filters from Cypress **`expose`**, not `env`. Do **not** use `-e grepTags=...` or `CYPRESS_grepTags` alone — they are ignored by grep v6.
+
+Tag filters are passed via `--expose` as comma-separated key/value pairs:
+
+```bash
+npx cypress run --expose grepTags=@personal-details+-@ignore,grepFilterSpecs=true
+```
+
+| Setting | Purpose |
+|---------|---------|
+| `grepTags` | Which tests to include/exclude |
+| `grepFilterSpecs=true` | Only load spec files that contain matching tests (avoids walking all 29 files) |
+| `grepOmitFiltered=true` | Omit non-matching tests from output (set in `cypress.config.js` and CI) |
+
+`cypress/plugins/grep-config.js` bridges `grepTags` onto `config.expose` before the grep plugin runs (from `--expose`, legacy `env.grepTags`, or `CYPRESS_grepTags`). On startup you should see:
+
+```text
+@cypress/grep: configured grepTags="@Production+-@ignore+-@device"
+@cypress/grep: filtering using tag(s) "..."
+```
+
+If those lines are **missing**, tag filtering is not active and the full suite will run.
+
+**CLI tip:** use `+` between tags for AND/exclusions in npm scripts and CI. Spaces inside `grepTags` values can be split by the shell, which was the cause of production/smoke appearing to run the same full suite locally.
+
+Convenience scripts in `package.json` already pass the correct tags:
+
+| Script | `grepTags` | Spec scope | Purpose |
+|--------|------------|------------|---------|
+| `npm run test:cypress:run` | `-@GoogleLighthouse+-@Accessibility+-@ignore+-@device` | matching specs only | Default local/CI-style run |
+| `npm run test:cypress:smoke` | `@SmokeTest+-@ignore` | matching specs only | Smoke tests only |
+| `npm run test:cypress:production` | `@Production+-@ignore+-@device` | `home.cy.js` only | Production-safe home page tests |
+| `npm run test:cypress:staging:devices` | `@device+-@ignore` | matching specs only | Device viewport tests |
+| `npm run test:cypress:accessibility` | `@Accessibility` | matching specs only | Accessibility-tagged tests |
+| `npm run test:cypress:GoogleLighthouse` | `@GoogleLighthouse` | matching specs only | Lighthouse tests (if wired) |
+
+**Tag combination rules** (`@cypress/grep`):
+
+- Space-separated tags use **OR** logic when passed as separate tokens (avoid in npm scripts; CI now uses `+` throughout).
+- Use `+` for **AND** logic: `@SmokeTest+@personal-details` or `-@ignore+-@device+@personal-details`.
+- Prefix with `-` to exclude: `@Production+-@ignore+-@device` means must have `@Production`, must not have `@ignore` or `@device`.
+
+More detail: [@cypress/grep — filter with tags](https://www.npmjs.com/package/@cypress/grep#filter-with-tags).
 
 ## Running the tests in the pipeline
-The tests are configured to run in the pipeline as per the CircleCi config.yml
 
-Every test not tagged `@GoogleLighthouse`, `@Accessibility`, `@ignore` or `@device` will run on a CI run of the e2e pipeline (i.e. when a change is made to this repository on any of its branches). Because each feature is ran in parallel within separate containers, you will need to ensure that each of CircleCi's jobs' `parallelism` properties are correctly set to the number of feature files, or parallelism is disabled (by removing the key and property from the job), otherwise the tests won't run correctly.
+The tests are configured in `.circleci/config.yml`. Tag filters are passed to Cypress via `--expose` (comma-separated), with `grepFilterSpecs=true` on all runs. Production additionally passes `--spec cypress/e2e/home.cy.js`.
 
-When triggered externally by the MTFH micro frontends as part of that particular CI workflow, it will  run tests related to that mfe, again without the aforementioned tags, in both `development` and `staging` environments. This works by utilising cucumber's built-in tagging system. When creating new feature files, make sure to tag them with the correct microfrontend name. For example, `mtfh-frontend-personal-details` would become `@personal-details`. Once these tests have ran (and passed) they will trigger a downstream deployment of the parent micro frontend to an elevated environment (successful tests that ran against `development` will trigger a deployment to `staging` etc.). In `production` it will only run tests that have been explicitly tagged with `@Production`. 
+```bash
+./node_modules/.bin/cypress run --expose "grepTags=${GREP_TAGS},grepFilterSpecs=true,grepOmitFiltered=true" --spec cypress/e2e/home.cy.js  # production only
+```
+
+### What runs where and when
+
+| Workflow | Trigger | Environment | `grepTags` | What runs |
+|----------|---------|-------------|------------|-----------|
+| `run-ci-tests` | Push/PR to this repo (`run_workflow_ci: true`) | development | `-@GoogleLighthouse+-@Accessibility+-@ignore+-@device` | All tests except excluded tags |
+| `e2e-tests-development` | External MFE pipeline (`external_trigger` + `development_environment`) | development | Above `+@<mfe>` or `+@SmokeTest`¹ | Tests for the triggering MFE only |
+| `e2e-tests-staging` | External MFE pipeline after dev promotion | staging | Same as development | Tests for the triggering MFE only |
+| `e2e-tests-production` | External MFE pipeline after staging promotion | production | `@Production+-@ignore+-@device` + `home.cy.js` | **Only** `@Production` tests — no MFE or smoke filter |
+| `e2e-tests-devices` | Weekly schedule (Tuesdays, `master` branch) | staging | `-@GoogleLighthouse+-@Accessibility+-@ignore+@device` | Device viewport tests only |
+
+¹ When the upstream MFE is `common`, `authentication`, or `root`, the filter is remapped to `@SmokeTest`.
+
+### External MFE triggers (development & staging)
+
+When an MTFH microfrontend pipeline triggers these tests, `upstream_pipeline_name` is used to derive an MFE tag (e.g. `mtfh-frontend-personal-details` → `@personal-details`). Matching tests run in **development** first; on success, the MFE is deployed to **staging** and the same scoped tests run again. On staging success, production deployment is triggered.
+
+Tag each spec with the related microfrontend name (e.g. `@personal-details`) so it runs during that MFE's deployment workflow.
+
+### Production
+
+Production runs **only** tests explicitly tagged `@Production`. Today that is the home page spec (`home.cy.js`). The pipeline applies three safeguards:
+
+1. **Tag filter only** — `@Production+-@ignore+-@device` (no `@SmokeTest` or MFE tag appended)
+2. **Spec pre-filter** — `grepFilterSpecs=true`
+3. **Hard spec pin** — `--spec cypress/e2e/home.cy.js`
+
+Smoke tests (`@SmokeTest`) and MFE-scoped tags cannot leak into production.
+
+### CI runs of this repository
+
+Every test not tagged `@GoogleLighthouse`, `@Accessibility`, `@ignore`, or `@device` runs when a change is made to this repository. Parallelism in CircleCI jobs must match the number of spec files (or be disabled), otherwise tests may not run correctly across containers.
 
 #### Further testing resources
 Further resources around creating tests can be found [here](https://drive.google.com/drive/folders/1XRqzngDYWvpfeJov1hbyJ_vBa88Ex2R4)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ npx cypress run --expose grepTags=@personal-details+-@ignore,grepFilterSpecs=tru
 | `grepFilterSpecs=true` | Only load spec files that contain matching tests (avoids walking all 29 files) |
 | `grepOmitFiltered=true` | Omit non-matching tests from output (set in `cypress.config.js` and CI) |
 
-`cypress/plugins/grep-config.js` bridges `grepTags` onto `config.expose` before the grep plugin runs (from `--expose`, legacy `env.grepTags`, or `CYPRESS_grepTags`). On startup you should see:
+`cypress/plugins/grep-config.js` copies `--expose` values onto `config.expose` before the grep plugin runs. On startup you should see:
 
 ```text
 @cypress/grep: configured grepTags="@Production+-@ignore+-@device"

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -17,6 +17,9 @@ module.exports = defineConfig({
   },
   chromeWebSecurity: false,
   video: true,
+  expose: {
+    grepOmitFiltered: true,
+  },
   e2e: {
     setupNodeEvents(on, config) {
       return require('./cypress/plugins/index.js')(on, config)
@@ -25,8 +28,5 @@ module.exports = defineConfig({
     experimentalMemoryManagement: true,
     numTestsKeptInMemory: 25,
     supportFile: 'cypress/support/e2e.js',
-    env: {
-      grepOmitFiltered: true,
-    },
   },
 })

--- a/cypress/plugins/dynamoDb-tasks.js
+++ b/cypress/plugins/dynamoDb-tasks.js
@@ -57,7 +57,6 @@ async function deleteRecord(record, { assetEndpoint, token }) {
     }
 
     const result = await docClient.delete({ TableName: tableName, Key: key }).promise();
-    console.log(`A record has been deleted from DynamoDb table ${tableName}:`, result);
     return result;
   } catch (deleteError) {
     console.log('A record is not deleted:', deleteError);

--- a/cypress/plugins/grep-config.js
+++ b/cypress/plugins/grep-config.js
@@ -1,0 +1,48 @@
+/**
+ * Normalise @cypress/grep v6 settings onto config.expose before the grep plugin runs.
+ *
+ * Cypress 15 reads grepTags from expose (not env). CLI/npm quoting can drop or split
+ * space-separated tag strings, so we also accept CYPRESS_grepTags and legacy env.grepTags.
+ */
+function applyGrepExpose(config) {
+  config.expose = {
+    grepOmitFiltered: true,
+    ...(config.expose || {}),
+  };
+
+  const exposeArg = process.argv.find((arg, index) => {
+    const flag = process.argv[index - 1];
+    return flag === '--expose' || flag === '-x';
+  });
+
+  if (exposeArg) {
+    const grepTagsMatch = exposeArg.match(/grepTags=([^,]+)/);
+    if (grepTagsMatch && !config.expose.grepTags) {
+      config.expose.grepTags = grepTagsMatch[1].trim();
+    }
+
+    if (/grepFilterSpecs=true/i.test(exposeArg)) {
+      config.expose.grepFilterSpecs = true;
+    }
+  }
+
+  const grepTags =
+    config.expose.grepTags ??
+    config.expose['grep-tags'] ??
+    config.env?.grepTags ??
+    process.env.CYPRESS_grepTags;
+
+  if (grepTags) {
+    config.expose.grepTags = grepTags;
+  }
+
+  if (config.expose.grepTags) {
+    console.log(`@cypress/grep: configured grepTags="${config.expose.grepTags}"`);
+  }
+
+  return config;
+}
+
+module.exports = {
+  applyGrepExpose,
+};

--- a/cypress/plugins/grep-config.js
+++ b/cypress/plugins/grep-config.js
@@ -1,8 +1,9 @@
 /**
- * Normalise @cypress/grep v6 settings onto config.expose before the grep plugin runs.
+ * Ensure @cypress/grep v6 settings are on config.expose before the grep plugin runs.
  *
- * Cypress 15 reads grepTags from expose (not env). CLI/npm quoting can drop or split
- * space-separated tag strings, so we also accept CYPRESS_grepTags and legacy env.grepTags.
+ * Cypress 15 / @cypress/grep v6 read grepTags from expose (via --expose), not env.
+ * This bridges CLI --expose values onto config.expose when Cypress has not already
+ * populated them (e.g. npm-script quoting edge cases).
  */
 function applyGrepExpose(config) {
   config.expose = {
@@ -16,7 +17,10 @@ function applyGrepExpose(config) {
   });
 
   if (exposeArg) {
+    // Capture group is the value after grepTags=, up to the next comma.
+    // e.g. "grepTags=@SmokeTest+-@ignore,grepFilterSpecs=true" → "@SmokeTest+-@ignore"
     const grepTagsMatch = exposeArg.match(/grepTags=([^,]+)/);
+
     if (grepTagsMatch && !config.expose.grepTags) {
       config.expose.grepTags = grepTagsMatch[1].trim();
     }
@@ -24,16 +28,6 @@ function applyGrepExpose(config) {
     if (/grepFilterSpecs=true/i.test(exposeArg)) {
       config.expose.grepFilterSpecs = true;
     }
-  }
-
-  const grepTags =
-    config.expose.grepTags ??
-    config.expose['grep-tags'] ??
-    config.env?.grepTags ??
-    process.env.CYPRESS_grepTags;
-
-  if (grepTags) {
-    config.expose.grepTags = grepTags;
   }
 
   if (config.expose.grepTags) {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -9,6 +9,7 @@ const { setEnvironmentConfig } = require('./environment-config');
 const { loadEnv, validateEnv } = require('./load-env');
 const { registerDynamoDbTasks } = require('./dynamoDb-tasks');
 const { registerAuditPlugin } = require('./audit-plugin');
+const { applyGrepExpose } = require('./grep-config');
 
 module.exports = async (on, config) => {
   let runtimeConfig = config;
@@ -16,6 +17,7 @@ module.exports = async (on, config) => {
   config = await setEnvironmentConfig(on, config);
   config = loadEnv(config);
   validateEnv(config);
+  config = applyGrepExpose(config);
   runtimeConfig = config;
 
   registerDynamoDbTasks(on, () => runtimeConfig);

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "test:cypress:open": "cypress open -e grepTags='-@ignore'",
-    "test:cypress:run": "cypress run -e grepTags='-@GoogleLighthouse -@Accessibility -@ignore -@device'",
-    "test:cypress:run:local": "cypress run -e grepTags='-@GoogleLighthouse -@Accessibility -@ignore -@device' --config video=false,retries=0,screenshotOnRunFailure=false",
-    "test:cypress:production": "cypress run -e grepTags='@Production -@ignore'",
-    "test:cypress:accessibility": "cypress run -e grepTags='@Accessibility'",
-    "test:cypress:GoogleLighthouse": "cypress run -e grepTags='@GoogleLighthouse'",
-    "test:cypress:staging:devices": "cypress run --browser chrome --headless -e grepTags='@device -@ignore'",
-    "test:cypress:smoke": "cypress run --browser chrome --headless -e grepTags='@SmokeTest -@ignore'"
+    "test:cypress:open": "cypress open --expose grepTags=-@ignore",
+    "test:cypress:run": "cypress run --expose grepTags=-@GoogleLighthouse+-@Accessibility+-@ignore+-@device,grepFilterSpecs=true",
+    "test:cypress:run:local": "cypress run --expose grepTags=-@GoogleLighthouse+-@Accessibility+-@ignore+-@device,grepFilterSpecs=true --config video=false,retries=0,screenshotOnRunFailure=false",
+    "test:cypress:production": "cypress run --expose grepTags=@Production+-@ignore+-@device,grepFilterSpecs=true --spec cypress/e2e/home.cy.js",
+    "test:cypress:accessibility": "cypress run --expose grepTags=@Accessibility,grepFilterSpecs=true",
+    "test:cypress:GoogleLighthouse": "cypress run --expose grepTags=@GoogleLighthouse,grepFilterSpecs=true",
+    "test:cypress:staging:devices": "cypress run --browser chrome --headless --expose grepTags=@device+-@ignore,grepFilterSpecs=true",
+    "test:cypress:smoke": "cypress run --browser chrome --headless --expose grepTags=@SmokeTest+-@ignore,grepFilterSpecs=true"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
# Fix Cypress grep tag filtering

## Overview

After upgrading to **Cypress 15** and **`@cypress/grep` v6**, tag-based test filtering in CircleCI and local npm scripts had silently stopped working. Running `npm run test:cypress:production` locally could walk all 29 spec files and execute tests such as `changeOfName.cy.js` — even though only `home.cy.js` is tagged `@Production`.

This change restores tag filtering end-to-end by:

- Passing `grepTags` through Cypress **`expose`** (`--expose`), not **`env`** (`-e` / `CYPRESS_grepTags` alone)
- Bridging `grepTags` in `cypress/plugins/grep-config.js` so CLI/npm quoting issues cannot silently disable filtering
- Using `+` for AND/exclusions in npm scripts (avoids shell splitting space-separated tag strings)
- Enabling `grepFilterSpecs=true` so only matching spec files are loaded
- Pinning `--spec cypress/e2e/home.cy.js` for production runs
- Isolating production from MFE/smoke `PIPELINE_FILTER` tags in CircleCI

---

## Root cause

### 1. `@cypress/grep` v6 reads `expose`, not `env`

Cypress 15.10+ deprecates `Cypress.env()` for public configuration. `@cypress/grep` v6 followed this migration:

| Mechanism | Before (v4 / Cypress 13) | After (v6 / Cypress 15) |
|-----------|--------------------------|-------------------------|
| CLI flag | `-e grepTags='@tag'` / `--env grepTags=...` | `--expose grepTags=...` |
| Env var | `CYPRESS_grepTags` → `config.env.grepTags` | Not read by grep v6 unless bridged |
| Runtime API | `Cypress.env('grepTags')` | `Cypress.expose('grepTags')` |
| Plugin | `config.env.grepTags` | `config.expose.grepTags` |

CircleCI was originally doing:

```bash
export CYPRESS_grepTags='...'
./node_modules/.bin/cypress run
```

The grep plugin and support-file registration never saw `grepTags` and **ran every spec** under `cypress/e2e/*.cy.js` with no tag filtering.

`grepOmitFiltered: true` had the same problem — it lived under `e2e.env` in `cypress.config.js` but grep v6 only checks `config.expose`.

### 2. Production was combining `@Production` with MFE/smoke tags (OR logic). This behaviour was intentional previously, but has been changed now to reduce the amount of test that run against production. Especially to remove tests that create records.

Even with working grep, the old CircleCI logic built production tags like:

```text
-@GoogleLighthouse -@Accessibility -@ignore @Production @SmokeTest -@device
```

`@cypress/grep` treats **space-separated positive tags as OR**:

- `@Production @SmokeTest` → run tests with `@Production` **or** `@SmokeTest`
- `@Production @personal-details` → run tests with `@Production` **or** `@personal-details`

Only `home.cy.js` has `@Production` at the `describe` level, but ~20 other specs have `@SmokeTest` on individual `it` blocks. The `PIPELINE_FILTER` block (derived from `upstream_pipeline_name`) ran on production as well as dev/staging, so smoke and MFE tests would have been included alongside home tests.

Only tests tagged with `@Production` should run against production to keep things safe and avoid accidentally creating records on live.

### 3. Local npm scripts: spaces in `grepTags` broke CLI parsing

The first fix migrated scripts to `-x grepTags='@Production -@ignore -@device'`, but **locally this still did not filter**. Space-separated values inside npm scripts can be split by the shell before Cypress receives them, so `config.expose.grepTags` was often unset. Symptom: production and smoke both listed all 29 specs and ran non-home tests such as `changeOfName.cy.js (9 of 29)`.

**Fix:** use `+` for AND/exclusions (`@Production+-@ignore+-@device`), enable `grepFilterSpecs=true`, add `grep-config.js` bridge, and pin `--spec cypress/e2e/home.cy.js` for production.

---

## Changes made

### `.circleci/config.yml`

Replaced the flat `CYPRESS_grepTags` export with three explicit `GREP_TAGS` branches and a shared Cypress invocation:

```bash
if [ trigger-context = external ] && [ stage = production ]; then
  GREP_TAGS='@Production+-@ignore+-@device'
  CYPRESS_SPEC='cypress/e2e/home.cy.js'
elif [ trigger-context = devices ]; then
  GREP_TAGS='-@GoogleLighthouse+-@Accessibility+-@ignore+@device'
else
  GREP_TAGS='-@GoogleLighthouse+-@Accessibility+-@ignore+-@device'
  # PIPELINE_FILTER appended with + (AND) — only applied for dev, staging, CI — NOT production
  ...
  export GREP_TAGS="$GREP_TAGS+@$PIPELINE_FILTER"
fi

CYPRESS_ARGS=(run --expose "grepTags=${GREP_TAGS},grepFilterSpecs=true,grepOmitFiltered=true")
[ -n "$CYPRESS_SPEC" ] && CYPRESS_ARGS+=(--spec "$CYPRESS_SPEC")
./node_modules/.bin/cypress "${CYPRESS_ARGS[@]}"
```

**Why this structure:**

- **Production** — dedicated tag string, no `PIPELINE_FILTER`, `grepFilterSpecs=true`, hard `--spec home.cy.js`
- **Devices** — unchanged `@device` inclusion
- **Everything else** (CI, external dev, external staging) — base exclusions (`+` between negatives) plus MFE/smoke tag appended with `+@$PIPELINE_FILTER` (AND, not space/OR)

### `cypress.config.js`

Moved `grepOmitFiltered: true` from `e2e.env` to top-level `expose`:

```js
expose: {
  grepOmitFiltered: true,
},
```

Filtered-out tests are omitted from the run entirely (not listed as skipped), which keeps CI output and timing accurate.

### `package.json`

All scripts use `--expose` with comma-separated values, `+` for AND/exclusions, and `grepFilterSpecs=true`. Production also pins the spec file:

```json
"test:cypress:production": "cypress run --expose grepTags=@Production+-@ignore+-@device,grepFilterSpecs=true --spec cypress/e2e/home.cy.js"
"test:cypress:smoke": "cypress run --browser chrome --headless --expose grepTags=@SmokeTest+-@ignore,grepFilterSpecs=true"
"test:cypress:run": "cypress run --expose grepTags=-@GoogleLighthouse+-@Accessibility+-@ignore+-@device,grepFilterSpecs=true"
```

### `cypress/plugins/grep-config.js` (new)

Bridges `grepTags` onto `config.expose` before the grep plugin runs, reading from:

1. `--expose` / `-x` CLI argument (parsed from `process.argv`)
2. `config.env.grepTags` (legacy `-e` usage)
3. `CYPRESS_grepTags` environment variable

Logs at startup:

```text
@cypress/grep: configured grepTags="@Production+-@ignore+-@device"
```

If this line is missing, tag filtering is not active.

### `cypress/plugins/index.js`

Calls `applyGrepExpose(config)` before `cypressGrepPlugin(config)`.

### `README.md`

Updated feature-tag docs, npm script table, pipeline table, production safeguards, and local verification guidance.

---

## What runs where and when

### CircleCI workflows

| Workflow | When it runs | Job | `trigger-context` | Stage | `grepTags` / spec |
|----------|--------------|-----|-------------------|-------|-------------------|
| `run-ci-tests` | Commit/PR to this repo | `run-ci-tests` | `ci` | development | `-@GoogleLighthouse+-@Accessibility+-@ignore+-@device` |
| `e2e-tests-development` | MFE pipeline promotes to dev | `run-e2e-tests` | `external` | development | Base exclusions `+@<mfe>` or `+@SmokeTest`¹ |
| `e2e-tests-staging` | MFE tests passed in dev | `run-e2e-tests` | `external` | staging | Same as development |
| `e2e-tests-production` | MFE tests passed in staging | `run-e2e-tests` | `external` | production | `@Production+-@ignore+-@device` + `home.cy.js` only |
| `e2e-tests-devices` | Cron: `0 0 * * 2` on `master` | `run-e2e-devices` | `devices` | staging | `-@GoogleLighthouse+-@Accessibility+-@ignore+@device` |

¹ `upstream_pipeline_name` is stripped to an MFE slug (e.g. `personal-details`). If the slug is `common`, `authentication`, or `root`, it is remapped to `SmokeTest`.

### External MFE promotion flow

```text
MFE build completes
    → triggers e2e-tests-development (scoped tests @<mfe>)
    → on pass: deploy MFE to staging
    → triggers e2e-tests-staging (same scoped tests)
    → on pass: deploy MFE to production
    → triggers e2e-tests-production (@Production only → home.cy.js)
```

Production is intentionally the narrowest gate: only tests explicitly approved for live (`@Production`) run against the real environment.

### What `@Production` runs today

Only `cypress/e2e/home.cy.js` is tagged `@Production`:

```js
describe('MMH Home page', { tags: ['@header', '@authentication', '@common', '@root', '@Production'] }, () => {
```

With `@Production+-@ignore+-@device`, grep selects all tests in that `describe` that are not tagged `@ignore` or `@device`. The home spec's viewport loop tests are **not** tagged `@device` at the `it` level, so they still run in production as part of the home page suite. Tests explicitly tagged `@device` in other specs are excluded by `-@device`.

To add more production-safe tests in future, tag their `describe` or `it` with `@Production`. Do **not** add `@SmokeTest` to production specs unless you intend them to run in dev/staging MFE workflows only.

### Production vs smoke — they must not look the same

| Command | Spec files loaded | Example test that runs | Example test that must NOT run |
|---------|-------------------|------------------------|-------------------------------|
| `npm run test:cypress:production` | `home.cy.js` only | `should show header and footer whilst logged in` | `changeOfName.cy.js` Happy path |
| `npm run test:cypress:smoke` | ~18 specs with `@SmokeTest` | `changeOfName.cy.js` Happy path | `home.cy.js` (no `@SmokeTest` tag) |

---

## Tag reference

| Tag | Meaning | Typical use |
|-----|---------|-------------|
| `@<mfe-name>` | Belongs to a microfrontend (e.g. `@personal-details`) | External dev/staging MFE pipelines |
| `@SmokeTest` | Critical path smoke test | Remapped from `common` / `authentication` / `root` MFEs |
| `@Production` | Safe to run against live production | Currently only `home.cy.js` |
| `@device` | Viewport / mobile layout test | Weekly devices job; excluded elsewhere |
| `@Accessibility` | cypress-axe accessibility audit | `npm run test:cypress:accessibility` only |
| `@GoogleLighthouse` | Lighthouse audit | Excluded from all CI; not wired in specs |
| `@ignore` | Skipped / broken test | Excluded everywhere |

### OR vs AND examples

```bash
# AND — MFE filter in CI (exclusions + required MFE tag)
cypress run --expose "grepTags=-@GoogleLighthouse+-@Accessibility+-@ignore+-@device+@personal-details,grepFilterSpecs=true"

# AND — tests with both tags (npm scripts)
cypress run --expose grepTags=@SmokeTest+@personal-details,grepFilterSpecs=true

# Include + exclude — must have @Production, must not have @ignore or @device
cypress run --expose grepTags=@Production+-@ignore+-@device,grepFilterSpecs=true --spec cypress/e2e/home.cy.js
```

---

## Files changed

| File | Change |
|------|--------|
| `.circleci/config.yml` | `GREP_TAGS` branches; production isolation; `--expose` + `grepFilterSpecs`; `--spec home.cy.js` for production |
| `cypress.config.js` | `grepOmitFiltered` moved to `expose` |
| `cypress/plugins/grep-config.js` | **New** — bridges `grepTags` onto `config.expose`; startup log |
| `cypress/plugins/index.js` | Calls `applyGrepExpose` before grep plugin |
| `package.json` | `--expose` with `+` tag syntax; `grepFilterSpecs=true`; production `--spec` |
| `README.md` | Tag docs, pipeline table, local verification |

---

## Test plan

- [x] `nvm use && npm ci`
- [x] `source setEnv.sh <profile> development` + export `CYPRESS_E2E_ACCESS_TOKEN_DEVELOPMENT`
- [x] `npm run test:cypress:run` — startup shows `configured grepTags` and `@cypress/grep: filtering using tag(s)`
- [x] `npm run test:cypress:smoke` — only specs with `@SmokeTest` load; does **not** run `home.cy.js`
- [x] `npm run test:cypress:production` — startup shows `grepTags="@Production+-@ignore+-@device"`; only `home.cy.js`
- [x] CircleCI `run-ci-tests` — full suite minus excluded tags
- [ ] CircleCI external production workflow — only `home.cy.js` in job logs
