### PR TITLE
SSI-899 Replace authentication with cognito-authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ commands:
                             export GREP_TAGS='-@GoogleLighthouse+-@Accessibility+-@ignore+-@device'
                             export PIPELINE_FILTER="$(echo << pipeline.parameters.upstream_pipeline_name >> | sed 's,https://github.com/LBHackney-IT/mtfh-frontend-,,g')"
                             if [ -n "$PIPELINE_FILTER" ]; then
-                              ( [ "$PIPELINE_FILTER" = "common" ] || [ "$PIPELINE_FILTER" = "authentication" ] || [ "$PIPELINE_FILTER" = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
+                              ( [ "$PIPELINE_FILTER" = "common" ] || [ "$PIPELINE_FILTER" = "cognito-authentication" ] || [ "$PIPELINE_FILTER" = "root" ] ) && export PIPELINE_FILTER="SmokeTest"
                               export GREP_TAGS="$GREP_TAGS+@$PIPELINE_FILTER"
                             fi
                           fi

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Open the Cypress runner console by using `npm run test:cypress:open`
 The e2e tests use tags to scope which tests run in a given pipeline or local command. Tags are set on `describe` or `it` blocks in `.cy.js` files, for example:
 
 ```js
-describe('Person page', { tags: ['@personal-details', '@authentication', '@common', '@root'] }, () => {
+describe('Person page', { tags: ['@personal-details', '@cognito-authentication', '@common', '@root'] }, () => {
   it('should view person details page', { tags: '@SmokeTest' }, () => { /* ... */ });
 });
 ```
@@ -135,7 +135,7 @@ The tests are configured in `.circleci/config.yml`. Tag filters are passed to Cy
 | `e2e-tests-production` | External MFE pipeline after staging promotion | production | `@Production+-@ignore+-@device` + `home.cy.js` | **Only** `@Production` tests — no MFE or smoke filter |
 | `e2e-tests-devices` | Weekly schedule (Tuesdays, `master` branch) | staging | `-@GoogleLighthouse+-@Accessibility+-@ignore+@device` | Device viewport tests only |
 
-¹ When the upstream MFE is `common`, `authentication`, or `root`, the filter is remapped to `@SmokeTest`.
+¹ When the upstream MFE is `common`, `cognito-authentication`, or `root`, the filter is remapped to `@SmokeTest`.
 
 ### External MFE triggers (development & staging)
 

--- a/cypress/e2e/activityHistoryPerson.cy.js
+++ b/cypress/e2e/activityHistoryPerson.cy.js
@@ -6,7 +6,7 @@ import ActivityHistoryPageObjects from '../pageObjects/activityHistoryPage';
 
 const activityHistory = new ActivityHistoryPageObjects("person");
 
-describe('Activity History for a person', { 'tags': ['@activity-history', '@authentication', '@common', '@root'] }, () => {
+describe('Activity History for a person', { 'tags': ['@activity-history', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/activityHistoryProperty.cy.js
+++ b/cypress/e2e/activityHistoryProperty.cy.js
@@ -4,7 +4,7 @@ import ActivityHistoryPageObjects from '../pageObjects/activityHistoryPage';
 const activityHistory = new ActivityHistoryPageObjects("property");
 
 
-describe('Activity History for a property', { 'tags': ['@activity-history', '@authentication', '@common', '@root'] }, () => {
+describe('Activity History for a property', { 'tags': ['@activity-history', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/activityHistoryTenure.cy.js
+++ b/cypress/e2e/activityHistoryTenure.cy.js
@@ -6,7 +6,7 @@ import ActivityHistoryPageObjects from '../pageObjects/activityHistoryPage';
 const activityHistory = new ActivityHistoryPageObjects("tenure");
 
 
-describe('Activity History for a tenure', { 'tags': ['@activity-history', '@authentication', '@common', '@root'] }, () => {
+describe('Activity History for a tenure', { 'tags': ['@activity-history', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/addPerson.cy.js
+++ b/cypress/e2e/addPerson.cy.js
@@ -4,7 +4,7 @@ import { queueDeletePersonWithId } from "../../api/helpers";
 import AddPersonFormObjects from '../pageObjects/addPersonForm';
 const addPersonPage = new AddPersonFormObjects();
 
-describe('Add a new person to a tenure', { tags: ['@tenure', '@authentication', '@common', '@root'] }, () => {
+describe('Add a new person to a tenure', { tags: ['@tenure', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabaseWithTenure(true);

--- a/cypress/e2e/cautionaryAlertCreate.cy.js
+++ b/cypress/e2e/cautionaryAlertCreate.cy.js
@@ -7,7 +7,7 @@ const personPage = new PersonPageObjects();
 const caPage = new CautionaryAlertsPageObjects();
 
 
-describe('Create Cautionary Alerts', { tags: ["@cautionary-alerts", "@authentication", "@common", "@root"] }, () => {
+describe('Create Cautionary Alerts', { tags: ["@cautionary-alerts", "@cognito-authentication", "@common", "@root"] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/cautionaryAlertEdit.cy.js
+++ b/cypress/e2e/cautionaryAlertEdit.cy.js
@@ -13,7 +13,7 @@ const getFormattedDate = (date) => {
     return typedDate;
 }
 
-describe("Edit Cautionary Alerts", { tags: ['@cautionary-alerts', '@authentication', '@common', '@root'] }, () => {
+describe("Edit Cautionary Alerts", { tags: ['@cautionary-alerts', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         seedDatabaseWithCautionaryAlert();
         cy.login();

--- a/cypress/e2e/cautionaryAlertView.cy.js
+++ b/cypress/e2e/cautionaryAlertView.cy.js
@@ -6,7 +6,7 @@ const personPO = new PersonPageObjects();
 const cautionaryAlertPage = new CautionaryAlertViewPageObject();
 
 
-describe('View cautionary alerts', { tags: ['@cautionary-alerts', '@authentication', '@common', '@root'] }, () => {
+describe('View cautionary alerts', { tags: ['@cautionary-alerts', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         seedDatabaseWithCautionaryAlert();
         cy.login();

--- a/cypress/e2e/changeAssetOwnership.cy.js
+++ b/cypress/e2e/changeAssetOwnership.cy.js
@@ -4,7 +4,7 @@ import { seedDatabase } from "../helpers/DbHelpers";
 const propertyPage = new PropertyPageObjects();
 
 
-describe('Change Asset Ownership', {tags: ['@property', '@authentication', '@common', '@root', '@search']}, ()=> {
+describe('Change Asset Ownership', {tags: ['@property', '@cognito-authentication', '@common', '@root', '@search']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/changeOfName.cy.js
+++ b/cypress/e2e/changeOfName.cy.js
@@ -6,7 +6,7 @@ import { seedDatabase, seedDatabaseWithChangeOfNameProcess } from "../helpers/Db
 const page = new ChangeOfNamePageObjects();
 const modal = new ModalPageObjects();
 
-describe("Change of Name Process", { tags: ['@processes', '@authentication', '@common', '@root', '@personal-details'] }, () => {
+describe("Change of Name Process", { tags: ['@processes', '@cognito-authentication', '@common', '@root', '@personal-details'] }, () => {
     let now = new Date();
 
     const minutesToMs = (minutes) => {

--- a/cypress/e2e/createEditTenure.cy.js
+++ b/cypress/e2e/createEditTenure.cy.js
@@ -10,7 +10,7 @@ const addPersonPage = new PersonFormObjects();
 const modal = new ModalPageObjects()
 const tenureTypes =  ['Freehold', 'Freehold (Serv)', 'Introductory', 'Leasehold (RTB)', 'License Temp Ac', 'Lse 100% Stair', 'Mesne Profit Ac', 'Non-Secure', 'Private Sale LH', 'Rent To Mortgage', 'Shared Equity', 'Shared Owners', 'Short Life Lse', 'Temp Annex', 'Temp B&B', 'Temp Decant', 'Temp Hostel', 'Temp Hostel Lse', 'Temp Private Lt', 'Temp Traveller', 'Tenant Acc Flat', 'Secure']
 
-describe('create and edit tenure', { tags: ['@tenure', '@authentication', '@common', '@root', '@search', '@worktray', '@personal-details']}, () => {
+describe('create and edit tenure', { tags: ['@tenure', '@cognito-authentication', '@common', '@root', '@search', '@worktray', '@personal-details']}, () => {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/editPatches.cy.js
+++ b/cypress/e2e/editPatches.cy.js
@@ -4,7 +4,7 @@ import PropertyPageObjects from "../pageObjects/propertyPage";
 const propertyPage = new PropertyPageObjects();
 
 
-describe.skip("edit patches on property page", {tags: ["@property", "@authentication", "@common", "@root"]}, () => {
+describe.skip("edit patches on property page", {tags: ["@property", "@cognito-authentication", "@common", "@root"]}, () => {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/editPerson.cy.js
+++ b/cypress/e2e/editPerson.cy.js
@@ -5,7 +5,7 @@ import { generateEqualityInformation } from '../../api/models/requests/equalityD
 const editPersonPage = new EditPersonFormObjects();
 
 
-describe('Edit a person', { tags: ['@activity-history', '@personal-details', '@authentication', '@common', '@root'] }, () => {
+describe('Edit a person', { tags: ['@activity-history', '@personal-details', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabaseWithTenure(true);

--- a/cypress/e2e/editPersonContactDetails.cy.js
+++ b/cypress/e2e/editPersonContactDetails.cy.js
@@ -8,7 +8,7 @@ const personContactPage = new PersonContactPageObjects();
 const contactTypes = ['email', 'phone']
 
 
-describe('Edit person Contact details', {tags: ['@personal-details', '@authentication', '@common', '@root', '@worktray']}, ()=> {
+describe('Edit person Contact details', {tags: ['@personal-details', '@cognito-authentication', '@common', '@root', '@worktray']}, ()=> {
     beforeEach(()=> {
         cy.login()
         const testPerson = person();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -8,7 +8,7 @@ const header = new HeaderPageObjects();
 const devices = ['ipad-2', 'ipad-mini', 'iphone-3', 'iphone-4', 'iphone-5', 'iphone-6', 'iphone-6+', 'iphone-7', 'iphone-8', 'iphone-xr', 'iphone-se2', 'macbook-11', 'macbook-13', 'macbook-15', 'macbook-16', 'samsung-note9', 'samsung-s10']
 
 
-describe('MMH Home page', {tags: ['@header', '@authentication', '@common', '@root', '@Production' ]}, ()=> {
+describe('MMH Home page', {tags: ['@header', '@cognito-authentication', '@common', '@root', '@Production' ]}, ()=> {
         
    
     it('should show header and footer whilst logged out', ()=> {

--- a/cypress/e2e/person-comments.cy.js
+++ b/cypress/e2e/person-comments.cy.js
@@ -19,7 +19,7 @@ function truncateString(str, num) {
 }
 
 
-describe('Person comments page', {tags: ['@comments', '@authentication', '@common', '@root']}, ()=> {
+describe('Person comments page', {tags: ['@comments', '@cognito-authentication', '@common', '@root']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/person.cy.js
+++ b/cypress/e2e/person.cy.js
@@ -15,7 +15,7 @@ const mockPersonContactDetails = (personId) => {
     }).as("getContactDetails");
 };
 
-describe('Person page', {tags: ['@personal-details', '@authentication', '@common', '@root', '@worktray']}, ()=> {
+describe('Person page', {tags: ['@personal-details', '@cognito-authentication', '@common', '@root', '@worktray']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabaseWithTenure(false);

--- a/cypress/e2e/personForm.cy.js
+++ b/cypress/e2e/personForm.cy.js
@@ -4,7 +4,7 @@ import EditPersonFormObjects from "../pageObjects/editPersonForm";
 const editPersonForm = new EditPersonFormObjects();
 
 
-describe('Person Form', { tags: ['@personal-details', '@authentication', '@common', '@root'] }, () => {
+describe('Person Form', { tags: ['@personal-details', '@cognito-authentication', '@common', '@root'] }, () => {
     beforeEach(() => {
         cy.login();
         seedDatabaseWithTenure(true);

--- a/cypress/e2e/process.cy.js
+++ b/cypress/e2e/process.cy.js
@@ -8,7 +8,7 @@ const tenureReqDocsPage = new TenureRequestDocsPageObjects();
 const tenureReviewDocsPage = new TenureReviewDocsPageObjects();
 
 
-describe('Processes menu', {tags: ['@process', '@common', '@root', '@authentication', '@personal-details']}, ()=> {
+describe('Processes menu', {tags: ['@process', '@common', '@root', '@cognito-authentication', '@personal-details']}, ()=> {
     beforeEach(()=> {
         cy.login()
         seedDatabase();

--- a/cypress/e2e/property-comments.cy.js
+++ b/cypress/e2e/property-comments.cy.js
@@ -22,7 +22,7 @@ function truncateString(str, num) {
 }
 
 
-describe('View property page', {tags: ['@property', '@authentication', '@common', '@root', '@comments']}, ()=> {
+describe('View property page', {tags: ['@property', '@cognito-authentication', '@common', '@root', '@comments']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/property.cy.js
+++ b/cypress/e2e/property.cy.js
@@ -11,7 +11,7 @@ import {
 const propertyPage = new PropertyPageObjects();
 const navigation = new NavigationPageObjects();
 
-describe('View property page', {tags: ['@property', '@authentication', '@common', '@root', '@search']}, ()=> {
+describe('View property page', {tags: ['@property', '@cognito-authentication', '@common', '@root', '@search']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/propertyAdd.cy.js
+++ b/cypress/e2e/propertyAdd.cy.js
@@ -10,7 +10,7 @@ const postcode = "MK40 2RF"
 const assetGuid = faker.datatype.uuid()
 
 
-describe('Add property', {tags: ['@property', '@authentication', '@common', '@root', '@search']}, ()=> {
+describe('Add property', {tags: ['@property', '@cognito-authentication', '@common', '@root', '@search']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/propertyEdit.cy.js
+++ b/cypress/e2e/propertyEdit.cy.js
@@ -7,7 +7,7 @@ const newAddressLine1Value = 'TEST Hackney'
 const noUprnValue = 'N/A'
 
 
-describe('Edit Property', {tags: ['@propety', '@authentication', '@common', '@root', '@search']}, ()=> {
+describe('Edit Property', {tags: ['@propety', '@cognito-authentication', '@common', '@root', '@search']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/relatedAssets.cy.js
+++ b/cypress/e2e/relatedAssets.cy.js
@@ -21,7 +21,7 @@ const generateChildrenAssetsFixture = (numberOfChildrenAssets = 0) => {
     return childrenAssetsResponseObject;
 }
 
-describe('Related assets', {tags: ['@property', '@authentication', '@common', '@root', '@search']}, () => {
+describe('Related assets', {tags: ['@property', '@cognito-authentication', '@common', '@root', '@search']}, () => {
     beforeEach(() => {
         cy.login();
         const testAsset = generateAsset();

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -9,7 +9,7 @@ const devices = [
 const numberOfResults = ['40', '20', '12']
 
 
-describe('Search Page',{tags: ['@search', '@authentication', '@common', '@root']}, ()=> {
+describe('Search Page',{tags: ['@search', '@cognito-authentication', '@common', '@root']}, ()=> {
     beforeEach(()=> {
         cy.login()
     })

--- a/cypress/e2e/tenure-comments.cy.js
+++ b/cypress/e2e/tenure-comments.cy.js
@@ -22,7 +22,7 @@ function truncateString(str, num) {
 }
 
 
-describe('tenure comments page', {tags: ['@comments', '@authentication', '@common', '@root']}, ()=> {
+describe('tenure comments page', {tags: ['@comments', '@cognito-authentication', '@common', '@root']}, ()=> {
     beforeEach(() => {
         cy.login();
         seedDatabaseWithTenure();

--- a/cypress/e2e/tenure.cy.js
+++ b/cypress/e2e/tenure.cy.js
@@ -11,7 +11,7 @@ const smallDevice = ['iphone-3', 'iphone-4', 'iphone-5', 'iphone-6', 'iphone-6+'
 const bigDevice = ['ipad-2', 'ipad-mini', 'macbook-11', 'macbook-11', 'macbook-13', 'macbook-15', 'macbook-16', 'samsung-note9']
 
 
-describe('tenure page', {tags: ['@tenure','@authentication', '@common', '@root', '@search', '@worktray', '@personal-details']}, () => {
+describe('tenure page', {tags: ['@tenure','@cognito-authentication', '@common', '@root', '@search', '@worktray', '@personal-details']}, () => {
     beforeEach(() => {
         cy.login();
         seedDatabaseWithTenure();

--- a/cypress/e2e/tenureRequestAndReviewDocuments.cy.js
+++ b/cypress/e2e/tenureRequestAndReviewDocuments.cy.js
@@ -44,7 +44,7 @@ function manualDataChecksPass({ id: tenureId, householdMembers }) {
     tenureReqDocsPage.successionNo().click();
 };
 
-describe('Request and review documents', {tags: ['@process', '@common', '@root', '@authentication', '@personal-details']}, ()=> {
+describe('Request and review documents', {tags: ['@process', '@common', '@root', '@cognito-authentication', '@personal-details']}, ()=> {
     beforeEach(()=> {
         cy.login();
         seedDatabase();

--- a/cypress/e2e/workTray.cy.js
+++ b/cypress/e2e/workTray.cy.js
@@ -5,7 +5,7 @@ const homePagePO = new homePage()
 const workTrayPO = new workTrayPage();
 
 
-describe.skip('Worktray Feature', {tags: ['@worktray', '@common', '@root', '@processes', '@authentication']}, ()=> {
+describe.skip('Worktray Feature', {tags: ['@worktray', '@common', '@root', '@processes', '@cognito-authentication']}, ()=> {
     beforeEach(()=> {
         cy.login();
         homePagePO.visit();


### PR DESCRIPTION
## Summary

Decommission the `@authentication` tag and replace it with `@cognito-authentication` to align with the new Cognito authentication MFE (`mtfh-frontend-cognito-authentication`). Test logic is unchanged — only tag names and pipeline/config references were updated.

## What changed

### Cypress specs (28 files)

All `describe`-level `@authentication` tags in `cypress/e2e/*.cy.js` were renamed to `@cognito-authentication`. No test steps, assertions, or `@SmokeTest` tags were modified.

**Before:**

```js
describe('Person page', { tags: ['@personal-details', '@authentication', '@common', '@root'] }, () => {
```

**After:**

```js
describe('Person page', { tags: ['@personal-details', '@cognito-authentication', '@common', '@root'] }, () => {
```

### CircleCI (`.circleci/config.yml`)

The upstream MFE slug remap for smoke tests now recognises `cognito-authentication` instead of `authentication`:

```bash
# Before
[ "$PIPELINE_FILTER" = "authentication" ]

# After
[ "$PIPELINE_FILTER" = "cognito-authentication" ]
```

When `upstream_pipeline_name` resolves to `common`, `cognito-authentication`, or `root`, the pipeline filter is still remapped to `@SmokeTest` (unchanged behaviour).

### README

Updated the tag example and the footnote describing the MFE → `@SmokeTest` remap.

## Why

The authentication microfrontend has been replaced by the Cognito authentication MFE. The old `@authentication` tag and `authentication` pipeline slug no longer reflect the deployed service name.

## Upstream dependency

The triggering MFE pipeline must use the repo slug `mtfh-frontend-cognito-authentication` so CircleCI derives `cognito-authentication` as the `PIPELINE_FILTER` value. The legacy `authentication` slug will no longer remap to smoke tests.
