### PR TITLE
Fix failing alert edit test

### DIFF
--- a/cypress/e2e/cautionaryAlertEdit.cy.js
+++ b/cypress/e2e/cautionaryAlertEdit.cy.js
@@ -6,7 +6,7 @@ const cautionaryAlertPage = new CautionaryAlertViewPageObject();
 
 const getFormattedDate = (date) => {
     const day = date.getDate().toString().padStart(2, '0');
-    const month = date.getMonth().toString().padStart(2, '0');
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
     const year = date.getFullYear().toString();
     // On the UI it's DD-MM-YYYY, however, cypress demands the opposite for it to work as expected.
     const typedDate = `${year}-${month}-${day}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "ws": ">=6.2.2"
       },
       "engines": {
-        "node": "24.17.x"
+        "node": "24.x.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "End to end tests for MTFH T&L",
   "main": "index.js",
   "engines": {
-    "node": "24.17.x"
+    "node": "24.x.x"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Failing because JS dates start at 0 for Jan for HTML inputs they start at 1 for Jan, so it crashes when the month date is 0