### PR TITLE
Fix flaky start date in tenure edit test

### DIFF
--- a/cypress/e2e/createEditTenure.cy.js
+++ b/cypress/e2e/createEditTenure.cy.js
@@ -3,6 +3,7 @@ import TenurePageObjects from "../pageObjects/tenurePage";
 import PersonFormObjects from "../pageObjects/personFormPage";
 import ModalPageObjects from "../pageObjects/sharedComponents/modal";
 import { seedDatabase } from "../helpers/DbHelpers";
+const { faker } = require("@faker-js/faker");
 
 const createTenurePage = new CreateTenurePageObjects();
 const tenurePage = new TenurePageObjects();
@@ -36,7 +37,7 @@ describe('create and edit tenure', { tags: ['@tenure', '@cognito-authentication'
             const searchTerm = "tre"
             createTenurePage.searchContainer().clear().type(searchTerm);
             createTenurePage.searchButton().click();
-            createTenurePage.searchResults().contains(searchTerm.replace(/\*/g, ""), { matchCase: false });});
+            createTenurePage.searchResults().contains(searchTerm.replace(/\*/g, ""), { matchCase: false });
             createTenurePage.addAsNamedTenureHolderButton().first().click()
             createTenurePage.pageAnnouncementContainer().should('contain', 'Person added to tenure');
 
@@ -53,6 +54,7 @@ describe('create and edit tenure', { tags: ['@tenure', '@cognito-authentication'
             tenurePage.tenureDetailsContainer().contains("Start date");
             tenurePage.tenureDetailsContainer().contains("End date");
             tenurePage.tenureDetailsContainer().contains("Type");
+        });
     })
 
     it('should create a new tenure and add a new person', ()=> {
@@ -211,7 +213,8 @@ describe('create and edit tenure', { tags: ['@tenure', '@cognito-authentication'
             cy.getTenureFixture(({ id: tenureId }) => {
                 cy.url().should('include', `tenure/${tenureId}/edit`)
             })
-            createTenurePage.tenureStartDateInput().clear().type("2000-05-20")
+            const pastDate = faker.date.past().toISOString().split("T")[0];
+            createTenurePage.tenureStartDateInput().clear().type(pastDate)
             cy.contains("Next").click();
             createTenurePage.doneButton().click()
             createTenurePage.confirmTenureUpdatedText().should('contain', 'Tenure updated');            


### PR DESCRIPTION
Currently, it was re-using the same tenure for subsequent edits, and the edits only work if the start date actually changes between test executions.

With this change it'll use a random start date for the existing tenure edit test.